### PR TITLE
Daemonize before starting tokio/async

### DIFF
--- a/netidx-tools/src/activation.rs
+++ b/netidx-tools/src/activation.rs
@@ -482,11 +482,7 @@ async fn run_server(cfg: Config, auth: DesiredAuth, params: Params) -> Result<()
 }
 
 #[tokio::main]
-pub(super) async fn tokio_run(
-    cfg: Config,
-    auth: DesiredAuth,
-    params: Params,
-) -> Result<()> {
+async fn tokio_run(cfg: Config, auth: DesiredAuth, params: Params) -> Result<()> {
     run_server(cfg, auth, params).await.context("activation")
 }
 

--- a/netidx-tools/src/activation.rs
+++ b/netidx-tools/src/activation.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use daemonize::Daemonize;
 use futures::{future::join_all, prelude::*, select_biased, stream::SelectAll};
 use log::{error, info, warn};
@@ -481,7 +481,16 @@ async fn run_server(cfg: Config, auth: DesiredAuth, params: Params) -> Result<()
     Ok(())
 }
 
-pub(super) async fn run(cfg: Config, auth: DesiredAuth, params: Params) -> Result<()> {
+#[tokio::main]
+pub(super) async fn tokio_run(
+    cfg: Config,
+    auth: DesiredAuth,
+    params: Params,
+) -> Result<()> {
+    run_server(cfg, auth, params).await.context("activation")
+}
+
+pub(super) fn run(cfg: Config, auth: DesiredAuth, params: Params) -> Result<()> {
     if !params.foreground {
         let mut d = Daemonize::new();
         if let Some(pid_file) = params.pid_file.as_ref() {
@@ -489,5 +498,5 @@ pub(super) async fn run(cfg: Config, auth: DesiredAuth, params: Params) -> Resul
         }
         d.start().context("failed to daemonize")?
     }
-    run_server(cfg, auth, params).await.context("activation")
+    tokio_run(cfg, auth, params)
 }

--- a/netidx-tools/src/resolver_server.rs
+++ b/netidx-tools/src/resolver_server.rs
@@ -23,17 +23,22 @@ pub(crate) struct Params {
     id: usize,
 }
 
-pub(crate) async fn run(params: Params) -> Result<()> {
-    let config =
-        Config::load(params.config).context("failed to load resolver server config")?;
+#[tokio::main]
+pub(crate) async fn tokio_run(config: Config, params: Params) -> Result<()> {
+    let _server = Server::new(config, params.delay_reads, params.id)
+        .await
+        .context("starting server")?;
+    future::pending::<Result<()>>().await
+}
+
+pub(crate) fn run(params: Params) -> Result<()> {
+    let config = Config::load(params.config.clone())
+        .context("failed to load resolver server config")?;
     let member = &config.member_servers[params.id];
     if !params.foreground {
         let mut file = member.pid_file.clone();
         file.push_str(&format!("{}.pid", params.id));
         Daemonize::new().pid_file(file).start().context("failed to daemonize")?;
     }
-    let _server = Server::new(config, params.delay_reads, params.id)
-        .await
-        .context("starting server")?;
-    future::pending::<Result<()>>().await
+    tokio_run(config, params)
 }

--- a/netidx-tools/src/resolver_server.rs
+++ b/netidx-tools/src/resolver_server.rs
@@ -24,7 +24,7 @@ pub(crate) struct Params {
 }
 
 #[tokio::main]
-pub(crate) async fn tokio_run(config: Config, params: Params) -> Result<()> {
+async fn tokio_run(config: Config, params: Params) -> Result<()> {
     let _server = Server::new(config, params.delay_reads, params.id)
         .await
         .context("starting server")?;


### PR DESCRIPTION
This should fix the hang on startup the resolver server was experiencing.

Aside: there are some inconsequential formatting changes that were introduced too. Not sure why my IDE applied different stuff.
