### PR TITLE
Fix a race condition when fetching args in a Rpc Proc

### DIFF
--- a/netidx-protocols/src/rpc.rs
+++ b/netidx-protocols/src/rpc.rs
@@ -513,10 +513,9 @@ pub mod client {
                                 .cast_to::<FxHashSet<Chars>>()
                                 .ok()
                                 .unwrap_or(HashSet::default());
-                            self.0
-                                .args
-                                .set(args)
-                                .map_err(|_| anyhow!("once cell set twice"))?;
+                            // Another thread may have set these args already,
+                            // so ignore if `set` returns Err.
+                            let _: Result<(), FxHashSet<Chars>> = self.0.args.set(args);
                             break;
                         }
                     }


### PR DESCRIPTION
If [call] is called on the same Proc simulatenously more than once, there is sometimes a race condition where we try to fetch and set args when the args have already been set, resulting in the error "once cell set twice".

This fixes the issue by making sure we check for the presence of args again after the final async call before doing so.