### PR TITLE
Support symlinked archive files

### DIFF
--- a/netidx-archive/src/logfile/arraymap.rs
+++ b/netidx-archive/src/logfile/arraymap.rs
@@ -116,16 +116,16 @@ where
     {
         match bound {
             Bound::Unbounded => match dir {
-		Dir::Fwd => 0,
-		Dir::Bwd => self.keys.len() - 1,
-	    },
+                Dir::Fwd => 0,
+		        Dir::Bwd => self.keys.len().saturating_sub(1),
+	        },
             Bound::Excluded(k) => {
                 match self.keys.binary_search_by(|key| key.borrow().cmp(k)) {
                     Err(i) => i,
                     Ok(i) => match dir {
-			Dir::Fwd => i + 1,
-			Dir::Bwd => i - 1,
-		    },
+                        Dir::Fwd => i + 1,
+                        Dir::Bwd => i - 1,
+		            },
                 }
             }
             Bound::Included(k) => {

--- a/netidx-archive/src/recorder/logfile_index.rs
+++ b/netidx-archive/src/recorder/logfile_index.rs
@@ -36,7 +36,7 @@ impl File {
             for dir in std::fs::read_dir(&path)? {
                 let dir = dir?;
                 let typ = dir.file_type()?;
-                if typ.is_file() {
+                if typ.is_file() || typ.is_symlink() {
                     let name = dir.file_name();
                     let name = name.to_string_lossy();
                     if name == "current" {
@@ -90,6 +90,10 @@ pub struct LogfileIndex(Arc<Vec<File>>);
 impl LogfileIndex {
     pub fn new(config: &Config, shard: &str) -> Result<Self> {
         Ok(Self(Arc::new(File::read(&config, shard)?)))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 
     pub fn first(&self) -> File {

--- a/netidx-core/src/pack.rs
+++ b/netidx-core/src/pack.rs
@@ -1333,7 +1333,7 @@ impl Pack for DateTime<Utc> {
         let ns = Pack::decode(buf)?;
         let ndt = NaiveDateTime::from_timestamp_opt(ts, ns)
             .ok_or_else(|| PackError::InvalidFormat)?;
-        Ok(DateTime::from_utc(ndt, Utc))
+        Ok(Utc.from_utc_datetime(&ndt))
     }
 }
 

--- a/netidx-netproto/src/value.rs
+++ b/netidx-netproto/src/value.rs
@@ -1269,9 +1269,8 @@ impl Value {
                         Ok(d) => Some(Value::Decimal(d)),
                         Err(_) => None,
                     },
-                    Typ::DateTime => Some(Value::DateTime(DateTime::from_utc(
-                        NaiveDateTime::from_timestamp_opt($v as i64, 0)?,
-                        Utc,
+                    Typ::DateTime => Some(Value::DateTime(Utc.from_utc_datetime(
+                        &NaiveDateTime::from_timestamp_opt($v as i64, 0)?,
                     ))),
                     Typ::Duration => {
                         Some(Value::Duration(Duration::from_secs($v as u64)))
@@ -1367,7 +1366,7 @@ impl Value {
                 Typ::Z64 => Some(Value::Z64(v.timestamp())),
                 Typ::F32 | Typ::F64 => {
                     let dur = v.timestamp() as f64;
-                    let dur = dur + (v.timestamp_nanos() / 1_000_000_000) as f64;
+                    let dur = dur + (v.timestamp_nanos_opt().expect("cannot represent as timestamp with ns precision") / 1_000_000_000) as f64;
                     if typ == Typ::F32 {
                         Some(Value::F32(dur as f32))
                     } else {


### PR DESCRIPTION
This PR changes the netidx recorder to be able to serve symlinked files. I think this has a number of useful applications, although the specific motivating example is NDA-ed.

Also addresses a few chores:

- Fix use of deprecated std functions; all of the diffs here should be no-ops (panic-able code remains panic-able)
- Fix edge case where recorder panics on reading/seeking empty archive file