### PR TITLE
Bug fixing for netidx-wsproxy

### DIFF
--- a/netidx-tools/src/wsproxy.rs
+++ b/netidx-tools/src/wsproxy.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use netidx::{
     publisher::PublisherBuilder, resolver_client::DesiredAuth, subscriber::Subscriber,
 };
+use std::time::Duration;
 
 use crate::publisher;
 
@@ -18,5 +19,6 @@ pub(super) async fn run(
         .await
         .context("creating publisher")?;
     let subscriber = Subscriber::new(cfg, auth).context("creating subscriber")?;
-    netidx_wsproxy::run(proxy, publisher, subscriber).await.context("ws proxy")
+    let timeout = pcfg.timeout.map(Duration::from_secs);
+    netidx_wsproxy::run(proxy, publisher, subscriber, timeout).await.context("ws proxy")
 }

--- a/netidx-wsproxy/src/config.rs
+++ b/netidx-wsproxy/src/config.rs
@@ -7,6 +7,9 @@ pub struct Config {
     #[structopt(long = "listen", help = "the websocket address/port to listen on")]
     pub listen: String,
     #[serde(default)]
+    #[structopt(long = "wstimeout", help = "the websocket timeout, unit: sec. example: 3.0")]
+    pub wstimeout: Option<f64>,
+    #[serde(default)]
     #[structopt(long = "cert", help = "path to the tls certificate")]
     pub cert: Option<String>,
     #[serde(default)]

--- a/netidx-wsproxy/src/config.rs
+++ b/netidx-wsproxy/src/config.rs
@@ -7,8 +7,8 @@ pub struct Config {
     #[structopt(long = "listen", help = "the websocket address/port to listen on")]
     pub listen: String,
     #[serde(default)]
-    #[structopt(long = "wstimeout", help = "the websocket timeout, unit: sec. example: 3.0")]
-    pub wstimeout: Option<f64>,
+    #[structopt(long = "timeout", help = "require subscribers to consume values before timeout (seconds)")]
+    pub timeout: Option<u64>,
     #[serde(default)]
     #[structopt(long = "cert", help = "path to the tls certificate")]
     pub cert: Option<String>,

--- a/netidx-wsproxy/src/config.rs
+++ b/netidx-wsproxy/src/config.rs
@@ -7,9 +7,6 @@ pub struct Config {
     #[structopt(long = "listen", help = "the websocket address/port to listen on")]
     pub listen: String,
     #[serde(default)]
-    #[structopt(long = "timeout", help = "require subscribers to consume values before timeout (seconds)")]
-    pub timeout: Option<u64>,
-    #[serde(default)]
     #[structopt(long = "cert", help = "path to the tls certificate")]
     pub cert: Option<String>,
     #[serde(default)]

--- a/netidx-wsproxy/src/lib.rs
+++ b/netidx-wsproxy/src/lib.rs
@@ -30,7 +30,7 @@ use warp::{
     ws::{Message, WebSocket, Ws},
     Filter, Reply,
 };
-use tokio::time::Duration;
+use std::time::Duration;
 
 pub mod config;
 mod protocol;
@@ -257,7 +257,7 @@ impl ClientCtx {
                 },
             }
         }
-        Ok(batch.commit(None).await)
+        Ok(batch.commit(timeout).await)
     }
 }
 
@@ -342,8 +342,9 @@ pub async fn run(
     config: config::Config,
     publisher: Publisher,
     subscriber: Subscriber,
+    timeout: Option<Duration>
 ) -> Result<()> {
-    let routes = filter(publisher, subscriber, "ws", config.timeout.map(Duration::from_secs));
+    let routes = filter(publisher, subscriber, "ws", timeout);
     match (&config.cert, &config.key) {
         (_, None) | (None, _) => {
             warp::serve(routes).run(config.listen.parse::<SocketAddr>()?).await


### PR DESCRIPTION
This PR fixes the bug of netidx-wsproxy we find before: A client's network error may block the netidx-wsproxy or make it very slow, described in https://github.com/netidx/netidx/issues/11

Currently the netidx-wsproxy creates many websocket connections, which share the same subscriber. And as you mentioned, the root cause is the timeout on the websocket is using the default tcp timeout, and it seems there is no way of changing this without changing warp.

We find another simpler way is to add a tokio timeout in the reply function that is used for the websocket server to send message to clients.  If one websocket reaches the timeout, we close that websocket connection, so it won't affect the other clients.

Another change in this PR is: The parameter timeout can be set by user for netidx-wsproxy, but it is not used before. We use this timeout for both the timeout of the reply function, and the publisher's timeout in the netidx-wsproxy project.
