### PR TITLE
Reorganize netidx-archive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "^0.4.24", features = ["serde"]}
 combine = "4"
 compact_str = { version = "0.7", features = ["serde"] }
 crossbeam = "0.8"
-cross-krb5 = { version = "0.4", default_features = false }
+cross-krb5 = { version = "0.4", default-features = false }
 digest = "0.10"
 dirs = "5"
 diligent-date-parser = "0.1.4"
@@ -55,7 +55,7 @@ parking_lot = "0.12.1"
 pin-utils = "0.1"
 pkcs8 = { version = "0.10", features = ["pem", "encryption"] }
 plotters-backend = "0.3"
-plotters = { version = "0.3", default_features = false, features = ["datetime", "line_series", "ttf"] }
+plotters = { version = "0.3", default-features = false, features = ["datetime", "line_series", "ttf"] }
 radix_trie = "0.2"
 rand = "0.8.5"
 rayon = "1"

--- a/netidx-archive/src/config.rs
+++ b/netidx-archive/src/config.rs
@@ -93,12 +93,28 @@ pub mod file {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct RecordShardConfig {
+        /// The globs defining the path space this shard will
+        /// record. This MUST be disjoint from the path space recorded
+        /// by any other shard.
+        ///
+        /// If spec is empty, then no recorder task will be started
+        /// for the shard, however the shard's `ArchiveCollectionWriter`
+        /// will be available so you can log to the shard directly.
         pub spec: Vec<Chars>,
+        /// override the poll_interval for this shard
         pub poll_interval: Option<Duration>,
+        /// override the image_frequency for this shard
         pub image_frequency: Option<usize>,
+        /// override the flush_frequency for this shard
         pub flush_frequency: Option<usize>,
+        /// override the flush_interval for this shard
         pub flush_interval: Option<Duration>,
+        /// override the rotate_interval for this shard
         pub rotate_interval: Option<RotateDirective>,
+        /// how much channel slack between subscriber and the recorder
+        /// task should this shard have. Higher numbers use more
+        /// memory but will reduce pushback on the publisher when the
+        /// disk is busy.
         #[serde(default = "default_slack")]
         pub slack: usize,
     }
@@ -112,7 +128,7 @@ pub mod file {
                 flush_frequency: None,
                 flush_interval: None,
                 rotate_interval: None,
-                slack: default_slack(),
+                slack: default_slack()
             }
         }
     }

--- a/netidx-archive/src/config.rs
+++ b/netidx-archive/src/config.rs
@@ -1,0 +1,390 @@
+use self::file::RecordShardConfig;
+use anyhow::Result;
+use arcstr::ArcStr;
+use netidx::{
+    chars::Chars,
+    config::Config as NetIdxCfg,
+    path::Path,
+    protocol::glob::Glob,
+    publisher::BindCfg,
+    resolver_client::{DesiredAuth, GlobSet},
+};
+use serde_derive::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
+
+pub mod file {
+    use super::RotateDirective;
+    use std::collections::HashMap;
+
+    use super::*;
+
+    pub fn default_max_sessions() -> usize {
+        512
+    }
+
+    pub fn default_max_sessions_per_client() -> usize {
+        64
+    }
+
+    pub fn default_oneshot_data_limit() -> usize {
+        104857600
+    }
+
+    pub fn default_cluster() -> String {
+        "cluster".into()
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct PublishConfig {
+        pub base: Path,
+        #[serde(default)]
+        pub bind: Option<String>,
+        #[serde(default = "default_max_sessions")]
+        pub max_sessions: usize,
+        #[serde(default = "default_max_sessions_per_client")]
+        pub max_sessions_per_client: usize,
+        #[serde(default = "default_oneshot_data_limit")]
+        pub oneshot_data_limit: usize,
+        #[serde(default)]
+        pub cluster_shards: Option<usize>,
+        #[serde(default = "default_cluster")]
+        pub cluster: String,
+    }
+
+    impl PublishConfig {
+        pub fn example() -> Self {
+            Self {
+                base: Path::from("/archive"),
+                bind: None,
+                max_sessions: default_max_sessions(),
+                max_sessions_per_client: default_max_sessions_per_client(),
+                oneshot_data_limit: default_oneshot_data_limit(),
+                cluster_shards: Some(0),
+                cluster: default_cluster(),
+            }
+        }
+    }
+
+    pub fn default_poll_interval() -> Option<Duration> {
+        Some(Duration::from_secs(5))
+    }
+
+    pub fn default_image_frequency() -> Option<usize> {
+        Some(67108864)
+    }
+
+    pub fn default_flush_frequency() -> Option<usize> {
+        Some(65534)
+    }
+
+    pub fn default_flush_interval() -> Option<Duration> {
+        Some(Duration::from_secs(30))
+    }
+
+    pub fn default_rotate_interval() -> RotateDirective {
+        RotateDirective::Interval(Duration::from_secs(86400))
+    }
+
+    pub fn default_slack() -> usize {
+        100
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct RecordShardConfig {
+        pub spec: Vec<Chars>,
+        pub poll_interval: Option<Duration>,
+        pub image_frequency: Option<usize>,
+        pub flush_frequency: Option<usize>,
+        pub flush_interval: Option<Duration>,
+        pub rotate_interval: Option<RotateDirective>,
+        #[serde(default = "default_slack")]
+        pub slack: usize,
+    }
+
+    impl RecordShardConfig {
+        pub fn example() -> Self {
+            Self {
+                spec: vec![Chars::from("/tmp/**")],
+                poll_interval: None,
+                image_frequency: None,
+                flush_frequency: None,
+                flush_interval: None,
+                rotate_interval: None,
+                slack: default_slack(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct RecordConfig {
+        #[serde(default = "default_poll_interval")]
+        pub poll_interval: Option<Duration>,
+        #[serde(default = "default_image_frequency")]
+        pub image_frequency: Option<usize>,
+        #[serde(default = "default_flush_frequency")]
+        pub flush_frequency: Option<usize>,
+        #[serde(default = "default_flush_interval")]
+        pub flush_interval: Option<Duration>,
+        #[serde(default = "default_rotate_interval")]
+        pub rotate_interval: RotateDirective,
+        pub shards: HashMap<ArcStr, RecordShardConfig>,
+    }
+
+    impl RecordConfig {
+        pub fn example() -> Self {
+            Self {
+                poll_interval: default_poll_interval(),
+                image_frequency: default_image_frequency(),
+                flush_frequency: default_flush_frequency(),
+                flush_interval: default_flush_interval(),
+                rotate_interval: default_rotate_interval(),
+                shards: HashMap::from([("0".into(), RecordShardConfig::example())]),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Config {
+        pub archive_directory: PathBuf,
+        #[serde(default)]
+        pub archive_cmds: Option<ArchiveCmds>,
+        #[serde(default)]
+        pub netidx_config: Option<PathBuf>,
+        #[serde(default)]
+        pub desired_auth: Option<DesiredAuth>,
+        #[serde(default)]
+        pub record: Option<RecordConfig>,
+        #[serde(default)]
+        pub publish: Option<PublishConfig>,
+    }
+
+    impl Config {
+        pub fn example() -> String {
+            serde_json::to_string_pretty(&Self {
+                archive_directory: PathBuf::from("/foo/bar"),
+                archive_cmds: Some(ArchiveCmds {
+                    list: (
+                        "cmd_to_list_dates_in_archive".into(),
+                        vec!["-s".into(), "{shard}".into()],
+                    ),
+                    get: (
+                        "cmd_to_fetch_file_from_archive".into(),
+                        vec!["-s".into(), "{shard}".into()],
+                    ),
+                    put: (
+                        "cmd_to_put_file_into_archive".into(),
+                        vec!["-s".into(), "{shard}".into()],
+                    ),
+                }),
+                netidx_config: None,
+                desired_auth: None,
+                record: Some(RecordConfig::example()),
+                publish: Some(PublishConfig::example()),
+            })
+            .unwrap()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum RotateDirective {
+    Interval(Duration),
+    Size(usize),
+    Never,
+}
+
+/// Configuration of the publish part of the recorder
+#[derive(Debug, Clone)]
+pub struct PublishConfig {
+    /// The base path to publish under
+    pub base: Path,
+    /// The publisher bind config. None to use the site default config.
+    pub bind: BindCfg,
+    /// The maximum number of client sessions
+    pub max_sessions: usize,
+    /// The maximum number of sessions per unique client
+    pub max_sessions_per_client: usize,
+    /// The maximum number of bytes a oneshot will return
+    pub oneshot_data_limit: usize,
+    /// How many external shards there are. e.g. instances on other
+    /// machines. This is used to sync up the cluster.
+    pub cluster_shards: Option<usize>,
+    /// The cluster name to join, default is "cluster".
+    pub cluster: String,
+}
+
+impl PublishConfig {
+    /// create a new PublishConfig with the specified base path and
+    /// all other parameters set to the default values.
+    pub fn new(netidx_cfg: &NetIdxCfg, base: Path) -> Self {
+        Self {
+            base,
+            bind: netidx_cfg.default_bind_config.clone(),
+            max_sessions: file::default_max_sessions(),
+            max_sessions_per_client: file::default_max_sessions_per_client(),
+            oneshot_data_limit: file::default_oneshot_data_limit(),
+            cluster_shards: None,
+            cluster: file::default_cluster(),
+        }
+    }
+
+    fn from_file(netidx_cfg: &NetIdxCfg, f: file::PublishConfig) -> Result<Self> {
+        Ok(Self {
+            base: f.base,
+            bind: f
+                .bind
+                .map(|s| s.parse::<BindCfg>())
+                .unwrap_or_else(|| Ok(netidx_cfg.default_bind_config.clone()))?,
+            max_sessions: f.max_sessions,
+            max_sessions_per_client: f.max_sessions_per_client,
+            oneshot_data_limit: f.oneshot_data_limit,
+            cluster_shards: f.cluster_shards,
+            cluster: f.cluster,
+        })
+    }
+}
+
+/// Configuration of the record part of the recorder
+#[derive(Debug, Clone)]
+pub struct RecordConfig {
+    /// the path spec globs to record
+    pub spec: GlobSet,
+    /// how often to poll the resolver for structure changes. None
+    /// means only once at startup.
+    pub poll_interval: Option<Duration>,
+    /// how often to write a full image. None means never write
+    /// images.
+    pub image_frequency: Option<usize>,
+    /// flush the file after the specified number of pages have
+    /// been written. None means never flush.
+    pub flush_frequency: Option<usize>,
+    /// flush the file after the specified elapsed time. None means
+    /// flush only on shutdown.
+    pub flush_interval: Option<Duration>,
+    /// rotate the log file at the specified interval or file size or
+    /// never.
+    pub rotate_interval: RotateDirective,
+    /// how much channel slack to allocate
+    pub slack: usize,
+}
+
+impl RecordConfig {
+    /// Create a new RecordConfig logging the specified globs with all
+    /// other parameters set to the default.
+    pub fn new(spec: GlobSet) -> Self {
+        Self {
+            spec,
+            poll_interval: file::default_poll_interval(),
+            image_frequency: file::default_image_frequency(),
+            flush_frequency: file::default_flush_frequency(),
+            flush_interval: file::default_flush_interval(),
+            rotate_interval: file::default_rotate_interval(),
+            slack: file::default_slack(),
+        }
+    }
+
+    fn from_file(f: file::RecordConfig) -> Result<HashMap<ArcStr, RecordConfig>> {
+        let mut shards = HashMap::default();
+        for (name, c) in f.shards {
+            let RecordShardConfig {
+                spec,
+                poll_interval,
+                image_frequency,
+                flush_frequency,
+                flush_interval,
+                rotate_interval,
+                slack,
+            } = c;
+            let res = RecordConfig {
+                spec: GlobSet::new(
+                    true,
+                    spec.into_iter().map(Glob::new).collect::<Result<Vec<_>>>()?,
+                )?,
+                poll_interval: poll_interval.or(f.poll_interval),
+                image_frequency: image_frequency.or(f.image_frequency),
+                flush_frequency: flush_frequency.or(f.flush_frequency),
+                flush_interval: flush_interval.or(f.flush_interval),
+                rotate_interval: rotate_interval.unwrap_or(f.rotate_interval),
+                slack,
+            };
+            shards.insert(name, res);
+        }
+        Ok(shards)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArchiveCmds {
+    pub list: (String, Vec<String>),
+    pub get: (String, Vec<String>),
+    pub put: (String, Vec<String>),
+}
+
+/// Configuration of the recorder
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// The directory where the archive files live. The current
+    /// archive will be called 'current', and previous rotated archive
+    /// files will be named with the rfc3339 timestamp that specifies
+    /// when they were rotated (and thus when they ended).
+    pub archive_directory: PathBuf,
+    pub archive_cmds: Option<ArchiveCmds>,
+    /// The netidx config to use
+    pub netidx_config: NetIdxCfg,
+    /// The netidx desired authentication mechanism to use
+    pub desired_auth: DesiredAuth,
+    /// Record. Each entry in the HashMap is a shard, which will
+    /// record independently to an archive directory under the base
+    /// directory. E.G. a shard named "0" will record under
+    /// ${archive_base}/0. If publish is specified all configured
+    /// shards on this instance will be published.
+    pub record: HashMap<ArcStr, RecordConfig>,
+    /// If specified this recorder will publish the archive
+    /// directory. It is possible for the same archiver to both record
+    /// and publish. One of record or publish must be specifed.
+    pub publish: Option<PublishConfig>,
+}
+
+impl TryFrom<file::Config> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(f: file::Config) -> Result<Self> {
+        let netidx_config = f
+            .netidx_config
+            .map(NetIdxCfg::load)
+            .unwrap_or_else(|| NetIdxCfg::load_default())?;
+        let desired_auth = f.desired_auth.unwrap_or_else(|| netidx_config.default_auth());
+        let publish =
+            f.publish.map(|f| PublishConfig::from_file(&netidx_config, f)).transpose()?;
+        Ok(Self {
+            archive_directory: f.archive_directory,
+            archive_cmds: f.archive_cmds,
+            netidx_config,
+            desired_auth,
+            record: f
+                .record
+                .map(|r| RecordConfig::from_file(r))
+                .transpose()?
+                .unwrap_or(HashMap::default()),
+            publish,
+        })
+    }
+}
+
+impl Config {
+    /// Load the config from the specified file
+    pub async fn load<F: AsRef<std::path::Path>>(file: F) -> Result<Config> {
+        let s = tokio::fs::read(file).await?;
+        let f = serde_json::from_slice::<file::Config>(&s)?;
+        Config::try_from(f)
+    }
+
+    pub fn example() -> String {
+        file::Config::example()
+    }
+}

--- a/netidx-archive/src/lib.rs
+++ b/netidx-archive/src/lib.rs
@@ -5,6 +5,8 @@ extern crate lazy_static;
 #[macro_use]
 extern crate anyhow;
 
+pub mod config;
 pub mod logfile;
+pub mod logfile_collection;
 pub mod recorder;
 pub mod recorder_client;

--- a/netidx-archive/src/logfile/mod.rs
+++ b/netidx-archive/src/logfile/mod.rs
@@ -628,10 +628,10 @@ fn scan_records(
         }
     };
     if let Some(deltamap) = deltamap {
-	deltamap.shrink_to_fit();
+        deltamap.shrink_to_fit();
     }
     if let Some(imagemap) = imagemap {
-	imagemap.shrink_to_fit();
+        imagemap.shrink_to_fit();
     }
     res
 }

--- a/netidx-archive/src/logfile_collection/index.rs
+++ b/netidx-archive/src/logfile_collection/index.rs
@@ -1,4 +1,4 @@
-use super::Config;
+use crate::config::Config;
 use anyhow::Result;
 use chrono::prelude::*;
 use log::{debug, info, warn};
@@ -64,7 +64,9 @@ impl File {
                     info!("list succeeded with {}", &stdout);
                     for name in stdout.split("\n") {
                         match name.parse::<DateTime<Utc>>() {
-                            Err(e) => warn!("failed to parse list ts \'{}\', {}", name, e),
+                            Err(e) => {
+                                warn!("failed to parse list ts \'{}\', {}", name, e)
+                            }
                             Ok(ts) => files.push(File::Historical(ts)),
                         }
                     }
@@ -85,9 +87,9 @@ impl File {
 }
 
 #[derive(Debug, Clone)]
-pub struct LogfileIndex(Arc<Vec<File>>);
+pub struct ArchiveIndex(Arc<Vec<File>>);
 
-impl LogfileIndex {
+impl ArchiveIndex {
     pub fn new(config: &Config, shard: &str) -> Result<Self> {
         Ok(Self(Arc::new(File::read(&config, shard)?)))
     }

--- a/netidx-archive/src/logfile_collection/mod.rs
+++ b/netidx-archive/src/logfile_collection/mod.rs
@@ -1,0 +1,3 @@
+pub mod reader;
+pub mod writer;
+pub mod index;

--- a/netidx-archive/src/logfile_collection/writer.rs
+++ b/netidx-archive/src/logfile_collection/writer.rs
@@ -1,0 +1,187 @@
+use crate::{
+    config::{ArchiveCmds, Config},
+    logfile::{ArchiveReader, ArchiveWriter, BatchItem, Id},
+};
+use anyhow::{Context, Result};
+use arcstr::ArcStr;
+use chrono::prelude::*;
+use log::{debug, info, warn};
+use netidx::{path::Path, pool::Pooled};
+use std::{
+    fs, iter,
+    path::{Path as FilePath, PathBuf},
+    sync::Arc,
+};
+
+/// Run archive PUT cmds on the given archive file
+pub fn put_file(
+    cmds: &Option<ArchiveCmds>,
+    shard_name: &str,
+    file_name: &str,
+) -> Result<()> {
+    debug!("would run put, cmd config {:?}", cmds);
+    if let Some(cmds) = cmds {
+        use std::process::Command;
+        info!("running put {:?}", &cmds.put);
+        let args =
+            cmds.put.1.iter().cloned().map(|arg| arg.replace("{shard}", shard_name));
+        let out = Command::new(&cmds.put.0)
+            .args(args.chain(iter::once(file_name.to_string())))
+            .output();
+        match out {
+            Err(e) => warn!("archive put failed for {}, {}", file_name, e),
+            Ok(o) if !o.status.success() => {
+                warn!("archive put failed for {}, {:?}", file_name, o)
+            }
+            Ok(out) => {
+                if out.stdout.len() > 0 {
+                    warn!("archive put stdout {}", String::from_utf8_lossy(&out.stdout));
+                }
+                if out.stderr.len() > 0 {
+                    warn!("archive put stderr {}", String::from_utf8_lossy(&out.stderr));
+                }
+                info!("put completed successfully");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub struct ArchiveCollectionWriter {
+    config: Arc<Config>,
+    shard_name: ArcStr,
+    base: PathBuf,
+    current_path: PathBuf,
+    external_lock: Option<(PathBuf, PathBuf)>,
+    current: Option<ArchiveWriter>,
+    pathindex: ArchiveWriter,
+}
+
+impl ArchiveCollectionWriter {
+    fn open_full<F: AsRef<FilePath>>(
+        config: Arc<Config>,
+        shard_name: ArcStr,
+        external_lock: Option<(F, F)>,
+    ) -> Result<Self> {
+        let base = config.archive_directory.join(shard_name.as_str());
+        let current_path = base.join("current");
+        let pathindex_path = base.join("pathindex");
+        fs::create_dir_all(&base)?;
+        let external_lock = external_lock.map(|(clock, plock)| {
+            (PathBuf::from(clock.as_ref()), PathBuf::from(plock.as_ref()))
+        });
+        let (current, pathindex) = if let Some((clock, plock)) = external_lock.as_ref() {
+            let current = ArchiveWriter::open_external(&current_path, clock)?;
+            let pathindex = ArchiveWriter::open_external(&pathindex_path, plock)?;
+            (current, pathindex)
+        } else {
+            (ArchiveWriter::open(&current_path)?, ArchiveWriter::open(&pathindex_path)?)
+        };
+        Ok(Self {
+            config,
+            shard_name,
+            base,
+            current_path,
+            external_lock,
+            current: Some(current),
+            pathindex,
+        })
+    }
+
+    pub fn open(config: Arc<Config>, shard_name: ArcStr) -> Result<Self> {
+        Self::open_full(config, shard_name, None::<(&FilePath, &FilePath)>)
+    }
+
+    /// Open the logfile collection with an external lock file for
+    /// both the current file and the path index. This will allow an
+    /// external process to write an archive file while another
+    /// process reads and/or publishes it.
+    ///
+    /// This could be dangerous, it is up to the caller to coordinate
+    /// the lock file name among writer processes to prevent multiple
+    /// concurrent writers.
+    pub fn open_external<F: AsRef<FilePath>>(
+        config: Arc<Config>,
+        shard_name: ArcStr,
+        external_lock: (F, F),
+    ) -> Result<Self> {
+        Self::open_full(config, shard_name, Some(external_lock))
+    }
+
+    fn current_mut(&mut self) -> Result<&mut ArchiveWriter> {
+        self.current.as_mut().ok_or_else(|| anyhow!("missing current, did rotate fail?"))
+    }
+
+    fn current(&self) -> Result<&ArchiveWriter> {
+        self.current.as_ref().ok_or_else(|| anyhow!("missing current, did rotate fail?"))
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.current_mut()?.flush()?;
+        self.pathindex.flush()
+    }
+
+    /// Write new path mappings to the pathmap file. See [ArchiveWriter::add_paths].
+    pub fn add_paths<'a>(
+        &'a mut self,
+        paths: impl IntoIterator<Item = &'a Path>,
+    ) -> Result<()> {
+        self.pathindex.add_paths(paths)
+    }
+
+    /// Write a batch to the current file. See [ArchiveWriter::add_batch].
+    pub fn add_batch(
+        &mut self,
+        image: bool,
+        timestamp: DateTime<Utc>,
+        batch: &Pooled<Vec<BatchItem>>,
+    ) -> Result<()> {
+        self.current_mut()?.add_batch(image, timestamp, batch)
+    }
+
+    pub fn id_for_path(&self, path: &Path) -> Option<Id> {
+        self.pathindex.id_for_path(path)
+    }
+
+    pub fn path_for_id(&self, id: &Id) -> Option<&Path> {
+        self.pathindex.path_for_id(id)
+    }
+
+    pub fn capacity(&self) -> Result<usize> {
+        Ok(self.current()?.capacity())
+    }
+
+    pub fn len(&self) -> Result<usize> {
+        Ok(self.current()?.len())
+    }
+
+    pub fn block_size(&self) -> Result<usize> {
+        Ok(self.current()?.block_size())
+    }
+
+    /// Return the reader for the current archive file. See [ArchiveWriter::reader]
+    pub fn current_reader(&self) -> Result<ArchiveReader> {
+        self.current()?.reader()
+    }
+
+    /// Return the reader for the pathindex. See [ArchiveWriter::reader]
+    pub fn pathindex_reader(&self) -> Result<ArchiveReader> {
+        self.pathindex.reader()
+    }
+
+    /// Rotate the current log file, replacing it with a new one, and
+    /// running any configured post rotate commands.
+    pub fn rotate(&mut self, now: DateTime<Utc>) -> Result<()> {
+        info!("rotating log file {}", now);
+        drop(self.current.take());
+        let now_str = now.to_rfc3339();
+        fs::rename(&self.current_path, &self.base.join(&now_str))
+            .context("renaming current")?;
+        put_file(&self.config.archive_cmds, &self.shard_name, &now_str)?;
+        self.current = Some(match self.external_lock.as_ref() {
+            Some((clock, _)) => ArchiveWriter::open_external(&self.current_path, clock)?,
+            None => ArchiveWriter::open(&self.current_path)?,
+        });
+        Ok(())
+    }
+}

--- a/netidx-archive/src/recorder/mod.rs
+++ b/netidx-archive/src/recorder/mod.rs
@@ -1,431 +1,76 @@
-use crate::logfile::{ArchiveReader, ArchiveWriter, BatchItem};
+use crate::{
+    config::{Config, ArchiveCmds},
+    logfile::{ArchiveReader, ArchiveWriter, BatchItem},
+    logfile_collection::{self, index::ArchiveIndex},
+};
 use anyhow::Result;
 use arcstr::ArcStr;
 use chrono::prelude::*;
 use fxhash::FxHashMap;
 use log::{debug, error, info, warn};
 use netidx::{
-    chars::Chars,
-    config::Config as NetIdxCfg,
-    path::Path,
-    pool::Pooled,
-    protocol::glob::Glob,
-    publisher::{BindCfg, PublisherBuilder},
-    resolver_client::{DesiredAuth, GlobSet},
+    pool::Pooled, publisher::PublisherBuilder, resolver_client::GlobSet,
     subscriber::Subscriber,
 };
 use netidx_core::atomic_id;
 use parking_lot::RwLock;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, iter, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashMap, iter, sync::Arc};
 use tokio::{sync::broadcast, task::JoinSet};
 
-use self::{file::RecordShardConfig, logfile_index::LogfileIndex};
-
-pub mod logfile_collection;
-pub mod logfile_index;
 mod oneshot;
 mod publish;
 mod record;
 
-pub mod file {
-    use super::RotateDirective;
-    use std::collections::HashMap;
-
-    use super::*;
-
-    pub fn default_max_sessions() -> usize {
-        512
-    }
-
-    pub fn default_max_sessions_per_client() -> usize {
-        64
-    }
-
-    pub fn default_oneshot_data_limit() -> usize {
-        104857600
-    }
-
-    pub fn default_cluster() -> String {
-        "cluster".into()
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct PublishConfig {
-        pub base: Path,
-        #[serde(default)]
-        pub bind: Option<String>,
-        #[serde(default = "default_max_sessions")]
-        pub max_sessions: usize,
-        #[serde(default = "default_max_sessions_per_client")]
-        pub max_sessions_per_client: usize,
-        #[serde(default = "default_oneshot_data_limit")]
-        pub oneshot_data_limit: usize,
-        #[serde(default)]
-        pub cluster_shards: Option<usize>,
-        #[serde(default = "default_cluster")]
-        pub cluster: String,
-    }
-
-    impl PublishConfig {
-        pub fn example() -> Self {
-            Self {
-                base: Path::from("/archive"),
-                bind: None,
-                max_sessions: default_max_sessions(),
-                max_sessions_per_client: default_max_sessions_per_client(),
-                oneshot_data_limit: default_oneshot_data_limit(),
-                cluster_shards: Some(0),
-                cluster: default_cluster(),
-            }
-        }
-    }
-
-    pub fn default_poll_interval() -> Option<Duration> {
-        Some(Duration::from_secs(5))
-    }
-
-    pub fn default_image_frequency() -> Option<usize> {
-        Some(67108864)
-    }
-
-    pub fn default_flush_frequency() -> Option<usize> {
-        Some(65534)
-    }
-
-    pub fn default_flush_interval() -> Option<Duration> {
-        Some(Duration::from_secs(30))
-    }
-
-    pub fn default_rotate_interval() -> RotateDirective {
-        RotateDirective::Interval(Duration::from_secs(86400))
-    }
-
-    pub fn default_slack() -> usize {
-        100
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct RecordShardConfig {
-        pub spec: Vec<Chars>,
-        pub poll_interval: Option<Duration>,
-        pub image_frequency: Option<usize>,
-        pub flush_frequency: Option<usize>,
-        pub flush_interval: Option<Duration>,
-        pub rotate_interval: Option<RotateDirective>,
-        #[serde(default = "default_slack")]
-        pub slack: usize,
-    }
-
-    impl RecordShardConfig {
-        pub fn example() -> Self {
-            Self {
-                spec: vec![Chars::from("/tmp/**")],
-                poll_interval: None,
-                image_frequency: None,
-                flush_frequency: None,
-                flush_interval: None,
-                rotate_interval: None,
-                slack: default_slack(),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct RecordConfig {
-        #[serde(default = "default_poll_interval")]
-        pub poll_interval: Option<Duration>,
-        #[serde(default = "default_image_frequency")]
-        pub image_frequency: Option<usize>,
-        #[serde(default = "default_flush_frequency")]
-        pub flush_frequency: Option<usize>,
-        #[serde(default = "default_flush_interval")]
-        pub flush_interval: Option<Duration>,
-        #[serde(default = "default_rotate_interval")]
-        pub rotate_interval: RotateDirective,
-        pub shards: HashMap<ArcStr, RecordShardConfig>,
-    }
-
-    impl RecordConfig {
-        pub fn example() -> Self {
-            Self {
-                poll_interval: default_poll_interval(),
-                image_frequency: default_image_frequency(),
-                flush_frequency: default_flush_frequency(),
-                flush_interval: default_flush_interval(),
-                rotate_interval: default_rotate_interval(),
-                shards: HashMap::from([("0".into(), RecordShardConfig::example())]),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Config {
-        pub archive_directory: PathBuf,
-        #[serde(default)]
-        pub archive_cmds: Option<ArchiveCmds>,
-        #[serde(default)]
-        pub netidx_config: Option<PathBuf>,
-        #[serde(default)]
-        pub desired_auth: Option<DesiredAuth>,
-        #[serde(default)]
-        pub record: Option<RecordConfig>,
-        #[serde(default)]
-        pub publish: Option<PublishConfig>,
-    }
-
-    impl Config {
-        pub fn example() -> String {
-            serde_json::to_string_pretty(&Self {
-                archive_directory: PathBuf::from("/foo/bar"),
-                archive_cmds: Some(ArchiveCmds {
-                    list: (
-                        "cmd_to_list_dates_in_archive".into(),
-                        vec!["-s".into(), "{shard}".into()],
-                    ),
-                    get: (
-                        "cmd_to_fetch_file_from_archive".into(),
-                        vec!["-s".into(), "{shard}".into()],
-                    ),
-                    put: (
-                        "cmd_to_put_file_into_archive".into(),
-                        vec!["-s".into(), "{shard}".into()],
-                    ),
-                }),
-                netidx_config: None,
-                desired_auth: None,
-                record: Some(RecordConfig::example()),
-                publish: Some(PublishConfig::example()),
-            })
-            .unwrap()
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub enum RotateDirective {
-    Interval(Duration),
-    Size(usize),
-    Never,
-}
-
-/// Configuration of the publish part of the recorder
-#[derive(Debug, Clone)]
-pub struct PublishConfig {
-    /// The base path to publish under
-    pub base: Path,
-    /// The publisher bind config. None to use the site default config.
-    pub bind: BindCfg,
-    /// The maximum number of client sessions
-    pub max_sessions: usize,
-    /// The maximum number of sessions per unique client
-    pub max_sessions_per_client: usize,
-    /// The maximum number of bytes a oneshot will return
-    pub oneshot_data_limit: usize,
-    /// How many external shards there are. e.g. instances on other
-    /// machines. This is used to sync up the cluster.
-    pub cluster_shards: Option<usize>,
-    /// The cluster name to join, default is "cluster".
-    pub cluster: String,
-}
-
-impl PublishConfig {
-    /// create a new PublishConfig with the specified base path and
-    /// all other parameters set to the default values.
-    pub fn new(netidx_cfg: &NetIdxCfg, base: Path) -> Self {
-        Self {
-            base,
-            bind: netidx_cfg.default_bind_config.clone(),
-            max_sessions: file::default_max_sessions(),
-            max_sessions_per_client: file::default_max_sessions_per_client(),
-            oneshot_data_limit: file::default_oneshot_data_limit(),
-            cluster_shards: None,
-            cluster: file::default_cluster(),
-        }
-    }
-
-    fn from_file(netidx_cfg: &NetIdxCfg, f: file::PublishConfig) -> Result<Self> {
-        Ok(Self {
-            base: f.base,
-            bind: f
-                .bind
-                .map(|s| s.parse::<BindCfg>())
-                .unwrap_or_else(|| Ok(netidx_cfg.default_bind_config.clone()))?,
-            max_sessions: f.max_sessions,
-            max_sessions_per_client: f.max_sessions_per_client,
-            oneshot_data_limit: f.oneshot_data_limit,
-            cluster_shards: f.cluster_shards,
-            cluster: f.cluster,
-        })
-    }
-}
-
-/// Configuration of the record part of the recorder
-#[derive(Debug, Clone)]
-pub struct RecordConfig {
-    /// the path spec globs to record
-    pub spec: GlobSet,
-    /// how often to poll the resolver for structure changes. None
-    /// means only once at startup.
-    pub poll_interval: Option<Duration>,
-    /// how often to write a full image. None means never write
-    /// images.
-    pub image_frequency: Option<usize>,
-    /// flush the file after the specified number of pages have
-    /// been written. None means never flush.
-    pub flush_frequency: Option<usize>,
-    /// flush the file after the specified elapsed time. None means
-    /// flush only on shutdown.
-    pub flush_interval: Option<Duration>,
-    /// rotate the log file at the specified interval or file size or
-    /// never.
-    pub rotate_interval: RotateDirective,
-    /// how much channel slack to allocate
-    pub slack: usize,
-}
-
-impl RecordConfig {
-    /// Create a new RecordConfig logging the specified globs with all
-    /// other parameters set to the default.
-    pub fn new(spec: GlobSet) -> Self {
-        Self {
-            spec,
-            poll_interval: file::default_poll_interval(),
-            image_frequency: file::default_image_frequency(),
-            flush_frequency: file::default_flush_frequency(),
-            flush_interval: file::default_flush_interval(),
-            rotate_interval: file::default_rotate_interval(),
-            slack: file::default_slack(),
-        }
-    }
-
-    fn from_file(f: file::RecordConfig) -> Result<HashMap<ArcStr, RecordConfig>> {
-        let mut shards = HashMap::default();
-        for (name, c) in f.shards {
-            let RecordShardConfig {
-                spec,
-                poll_interval,
-                image_frequency,
-                flush_frequency,
-                flush_interval,
-                rotate_interval,
-                slack,
-            } = c;
-            let res = RecordConfig {
-                spec: GlobSet::new(
-                    true,
-                    spec.into_iter().map(Glob::new).collect::<Result<Vec<_>>>()?,
-                )?,
-                poll_interval: poll_interval.or(f.poll_interval),
-                image_frequency: image_frequency.or(f.image_frequency),
-                flush_frequency: flush_frequency.or(f.flush_frequency),
-                flush_interval: flush_interval.or(f.flush_interval),
-                rotate_interval: rotate_interval.unwrap_or(f.rotate_interval),
-                slack,
-            };
-            shards.insert(name, res);
-        }
-        Ok(shards)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ArchiveCmds {
-    pub list: (String, Vec<String>),
-    pub get: (String, Vec<String>),
-    pub put: (String, Vec<String>),
-}
-
-/// Configuration of the recorder
-#[derive(Debug, Clone)]
-pub struct Config {
-    /// The directory where the archive files live. The current
-    /// archive will be called 'current', and previous rotated archive
-    /// files will be named with the rfc3339 timestamp that specifies
-    /// when they were rotated (and thus when they ended).
-    pub archive_directory: PathBuf,
-    pub archive_cmds: Option<ArchiveCmds>,
-    /// The netidx config to use
-    pub netidx_config: NetIdxCfg,
-    /// The netidx desired authentication mechanism to use
-    pub desired_auth: DesiredAuth,
-    /// Record. Each entry in the HashMap is a shard, which will
-    /// record independently to an archive directory under the base
-    /// directory. E.G. a shard named "0" will record under
-    /// ${archive_base}/0. If publish is specified all configured
-    /// shards on this instance will be published.
-    pub record: HashMap<ArcStr, RecordConfig>,
-    /// If specified this recorder will publish the archive
-    /// directory. It is possible for the same archiver to both record
-    /// and publish. One of record or publish must be specifed.
-    pub publish: Option<PublishConfig>,
-}
-
-impl TryFrom<file::Config> for Config {
-    type Error = anyhow::Error;
-
-    fn try_from(f: file::Config) -> Result<Self> {
-        let netidx_config = f
-            .netidx_config
-            .map(NetIdxCfg::load)
-            .unwrap_or_else(|| NetIdxCfg::load_default())?;
-        let desired_auth = f.desired_auth.unwrap_or_else(|| netidx_config.default_auth());
-        let publish =
-            f.publish.map(|f| PublishConfig::from_file(&netidx_config, f)).transpose()?;
-        Ok(Self {
-            archive_directory: f.archive_directory,
-            archive_cmds: f.archive_cmds,
-            netidx_config,
-            desired_auth,
-            record: f
-                .record
-                .map(|r| RecordConfig::from_file(r))
-                .transpose()?
-                .unwrap_or(HashMap::default()),
-            publish,
-        })
-    }
-}
-
-impl Config {
-    /// Load the config from the specified file
-    pub async fn load<F: AsRef<std::path::Path>>(file: F) -> Result<Config> {
-        let s = tokio::fs::read(file).await?;
-        let f = serde_json::from_slice::<file::Config>(&s)?;
-        Config::try_from(f)
-    }
-
-    pub fn example() -> String {
-        file::Config::example()
-    }
-}
-
 atomic_id!(ShardId);
 
 #[derive(Debug, Clone)]
-enum BCastMsg {
+pub enum BCastMsg {
     LogRotated(DateTime<Utc>),
     NewCurrent(ArchiveReader),
     Batch(DateTime<Utc>, Arc<Pooled<Vec<BatchItem>>>),
     TailInvalidated,
 }
 
-pub(crate) struct Shards {
+pub struct Shards {
     spec: FxHashMap<ShardId, GlobSet>,
     by_id: FxHashMap<ShardId, ArcStr>,
     by_name: FxHashMap<ArcStr, ShardId>,
-    indexes: RwLock<FxHashMap<ShardId, LogfileIndex>>,
+    indexes: RwLock<FxHashMap<ShardId, ArchiveIndex>>,
     pathindexes: FxHashMap<ShardId, ArchiveReader>,
     heads: RwLock<FxHashMap<ShardId, ArchiveReader>>,
     bcast: FxHashMap<ShardId, broadcast::Sender<BCastMsg>>,
 }
 
 impl Shards {
+    pub fn spec(&self) -> &FxHashMap<ShardId, GlobSet> {
+        &self.spec
+    }
+
+    pub fn by_id(&self) -> &FxHashMap<ShardId, ArcStr> {
+        &self.by_id
+    }
+
+    pub fn by_name(&self) -> &FxHashMap<ArcStr, ShardId> {
+        &self.by_name
+    }
+
+    pub fn indexes(&self) -> &RwLock<FxHashMap<ShardId, ArchiveIndex>> {
+        &self.indexes
+    }
+
+    pub fn pathindexes(&self) -> &FxHashMap<ShardId, ArchiveReader> {
+        &self.pathindexes
+    }
+    
+    pub fn heads(&self) -> &RwLock<FxHashMap<ShardId, ArchiveReader>> {
+        &self.heads
+    }
+
+    pub fn bcast(&self) -> &FxHashMap<ShardId, broadcast::Sender<BCastMsg>> {
+        &self.bcast
+    }
+
     fn read(
         config: &Arc<Config>,
     ) -> Result<(FxHashMap<ShardId, ArchiveWriter>, Arc<Self>)> {
@@ -444,7 +89,7 @@ impl Shards {
             let name = ArcStr::from(ent.file_name().to_string_lossy());
             if ent.file_type()?.is_dir() && &name != ".." {
                 let id = ShardId::new();
-                t.indexes.write().insert(id, LogfileIndex::new(&config, &name)?);
+                t.indexes.write().insert(id, ArchiveIndex::new(&config, &name)?);
                 t.by_id.insert(id, name.clone());
                 t.by_name.insert(name, id);
                 let indexpath = ent.path().join("pathindex");
@@ -475,7 +120,7 @@ impl Shards {
         let mut writers = HashMap::default();
         for (name, rcfg) in config.record.iter() {
             let id = ShardId::new();
-            t.indexes.write().insert(id, LogfileIndex::new(&config, &name)?);
+            t.indexes.write().insert(id, ArchiveIndex::new(&config, &name)?);
             t.by_id.insert(id, name.clone());
             t.by_name.insert(name.clone(), id);
             t.spec.insert(id, rcfg.spec.clone());
@@ -502,7 +147,7 @@ impl Shards {
     pub fn reopen(&self, ts: Option<DateTime<Utc>>) -> Result<()> {
         self.remap_rescan_pathindex()?;
         match ts {
-            Some(ts) => logfile_collection::reopen(ts)?,
+            Some(ts) => logfile_collection::reader::reopen(ts)?,
             None => {
                 let mut heads = self.heads.write();
                 for (_, reader) in heads.iter_mut() {
@@ -517,7 +162,7 @@ impl Shards {
     pub fn remap_rescan(&self, ts: Option<DateTime<Utc>>) -> Result<()> {
         self.remap_rescan_pathindex()?;
         match ts {
-            Some(ts) => logfile_collection::remap_rescan(ts)?,
+            Some(ts) => logfile_collection::reader::remap_rescan(ts)?,
             None => {
                 let heads = self.heads.read();
                 for (_, reader) in heads.iter() {
@@ -536,27 +181,23 @@ impl Shards {
         let mut indexes = self.indexes.write();
         for (shard, logfile_index) in indexes.iter_mut() {
             let name = self.by_id.get(shard).unwrap();
-            *logfile_index = LogfileIndex::new(config, name)?;
+            *logfile_index = ArchiveIndex::new(config, name)?;
         }
         Ok(())
     }
 }
 
 pub struct Recorder {
-    config: Arc<Config>,
     wait: JoinSet<()>,
+    pub config: Arc<Config>,
+    pub shards: Arc<Shards>
 }
 
 impl Recorder {
-    async fn start_jobs(&mut self) -> Result<()> {
+    async fn start_jobs(&mut self, mut writers: FxHashMap<ShardId, ArchiveWriter>) -> Result<()> {
         let config = self.config.clone();
         let subscriber =
             Subscriber::new(config.netidx_config.clone(), config.desired_auth.clone())?;
-        let (mut writers, shards) = if config.record.is_empty() {
-            Shards::read(&config)?
-        } else {
-            Shards::from_cfg(&config)?
-        };
         if let Some(publish_config) = config.publish.as_ref() {
             let publish_config = Arc::new(publish_config.clone());
             let publisher = PublisherBuilder::new(config.netidx_config.clone())
@@ -565,7 +206,7 @@ impl Recorder {
                 .build()
                 .await?;
             self.wait.spawn({
-                let shards = shards.clone();
+                let shards = self.shards.clone();
                 let publish_config = publish_config.clone();
                 let subscriber = subscriber.clone();
                 let config = config.clone();
@@ -586,7 +227,7 @@ impl Recorder {
             });
             self.wait.spawn({
                 let subscriber = subscriber.clone();
-                let shards = shards.clone();
+                let shards = self.shards.clone();
                 let publish_config = publish_config.clone();
                 let config = config.clone();
                 let publisher = publisher.clone();
@@ -607,7 +248,7 @@ impl Recorder {
         }
         for (name, cfg) in config.record.iter() {
             let name = name.clone();
-            let id = shards.by_name[&name];
+            let id = self.shards.by_name[&name];
             let pathindex_writer = writers.remove(&id).unwrap();
             let record_config = Arc::new(cfg.clone());
             let subscriber = Subscriber::new(
@@ -615,7 +256,7 @@ impl Recorder {
                 config.desired_auth.clone(),
             )?;
             let config = config.clone();
-            let shards = shards.clone();
+            let shards = self.shards.clone();
             self.wait.spawn(async move {
                 let r = record::run(
                     shards,
@@ -638,8 +279,13 @@ impl Recorder {
     /// Start the recorder
     pub async fn start(config: Config) -> Result<Self> {
         let config = Arc::new(config);
-        let mut t = Self { wait: JoinSet::new(), config };
-        t.start_jobs().await?;
+        let (writers, shards) = if config.record.is_empty() {
+            Shards::read(&config)?
+        } else {
+            Shards::from_cfg(&config)?
+        };
+        let mut t = Self { wait: JoinSet::new(), config, shards };
+        t.start_jobs(writers).await?;
         Ok(t)
     }
 }

--- a/netidx-archive/src/recorder/oneshot.rs
+++ b/netidx-archive/src/recorder/oneshot.rs
@@ -1,15 +1,13 @@
 use super::{
-    logfile_collection::LogfileCollection,
-    logfile_index::LogfileIndex,
+    logfile_collection::index::ArchiveIndex,
+    logfile_collection::reader::ArchiveCollectionReader,
     publish::{parse_bound, parse_filter},
     Shards,
 };
 use crate::{
+    config::{Config, PublishConfig},
     logfile::{ArchiveReader, BatchItem, Id, Seek, CURSOR_BATCH_POOL, IMG_POOL},
-    recorder::{
-        publish::{END_DOC, FILTER_DOC, START_DOC},
-        Config, PublishConfig,
-    },
+    recorder::publish::{END_DOC, FILTER_DOC, START_DOC},
     recorder_client::{OneshotReply, OneshotReplyShard, PATHMAPS, SHARDS},
 };
 use anyhow::Result;
@@ -104,7 +102,7 @@ impl OneshotConfig {
 async fn do_oneshot(
     shard: ArcStr,
     head: Option<ArchiveReader>,
-    index: LogfileIndex,
+    index: ArchiveIndex,
     pathindex: ArchiveReader,
     config: Arc<Config>,
     limit: usize,
@@ -131,7 +129,7 @@ async fn do_oneshot(
     }
     debug!("opening logfile collection");
     let mut log =
-        LogfileCollection::new(index, config, shard, head, args.start, args.end);
+        ArchiveCollectionReader::new(index, config, shard, head, args.start, args.end);
     debug!("seeking to beginning");
     log.seek(Seek::Beginning)?;
     debug!("reimaging");

--- a/netidx-tools/src/record_client.rs
+++ b/netidx-tools/src/record_client.rs
@@ -64,7 +64,7 @@ pub(crate) enum Cmd {
             default_value = "2"
         )]
         window: usize,
-        file: PathBuf,
+        file: Vec<PathBuf>,
     },
     #[structopt(name = "index", about = "index the archive file")]
     Index {
@@ -311,7 +311,12 @@ pub(super) async fn run(cmd: Cmd) -> Result<()> {
             let subscriber = Subscriber::new(cfg, auth).context("create subscriber")?;
             session(subscriber, params).await
         }
-        Cmd::Compress { file, window, keep } => compress(file, keep, window).await,
+        Cmd::Compress { file, window, keep } => {
+            for f in file {
+                compress(f, keep, window).await?
+            }
+            Ok(())
+        },
         Cmd::Dump { file, metadata, check_index } => dump(file, metadata, check_index),
         Cmd::Verify { file } => verify(file),
         Cmd::Compressed { file } => compressed(file),

--- a/netidx-tools/src/recorder.rs
+++ b/netidx-tools/src/recorder.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
-use netidx_archive::recorder::{Config, Recorder};
+use netidx_archive::{config::Config, recorder::Recorder};
 use std::{
     fs,
-    path::{self, PathBuf}, time::Duration,
+    path::{self, PathBuf},
+    time::Duration,
 };
 use tokio::signal::ctrl_c;
 


### PR DESCRIPTION
This adds another layer between the recorder and the raw logfile, called a logfile collection. This moves much of the functionality implemented directly in the recorder for dealing with rotating log file, pulling them from and pushing them to external storage, and compressing them out of the recorder into a set of objects that can be used directly.

In particular I have an use case where the application itself wants to write the log files directly without first publishing the data, and with the guarantee that the recorder never miss a single item, but it wants to expose the recorder interface to it's consumers. It occurs to me that other people probably want to do this too, and that a lot of the stuff we did in the recorder to make S3 storage compression, etc, work would be usable outside the recorder proper.
