### PR TITLE
Implement generic type parameters for typedefs

### DIFF
--- a/netidx-bscript/src/env.rs
+++ b/netidx-bscript/src/env.rs
@@ -1,14 +1,15 @@
 use crate::{
     expr::{Arg, ModPath},
-    typ::{FnType, Type},
+    typ::{FnType, Type, TVar},
     BindId, Ctx, InitFn, LambdaId, UserEvent,
 };
 use anyhow::{bail, Result};
 use arcstr::ArcStr;
 use compact_str::CompactString;
+use fxhash::{FxHashMap, FxHashSet};
 use immutable_chunkmap::{map::MapS as Map, set::SetS as Set};
 use netidx::path::Path;
-use std::{fmt, iter, ops::Bound, sync::Weak};
+use std::{fmt, iter, ops::Bound, sync::Weak, cell::RefCell};
 use triomphe::Arc;
 
 pub struct LambdaDef<C: Ctx, E: UserEvent> {
@@ -54,13 +55,19 @@ impl Clone for Bind {
     }
 }
 
+#[derive(Clone)]
+pub struct TypeDef {
+    pub params: Arc<[(TVar, Option<Type>)]>,
+    pub typ: Type,
+}
+
 pub struct Env<C: Ctx, E: UserEvent> {
     pub by_id: Map<BindId, Bind>,
     pub lambdas: Map<LambdaId, Weak<LambdaDef<C, E>>>,
     pub binds: Map<ModPath, Map<CompactString, BindId>>,
     pub used: Map<ModPath, Arc<Vec<ModPath>>>,
     pub modules: Set<ModPath>,
-    pub typedefs: Map<ModPath, Map<CompactString, Type>>,
+    pub typedefs: Map<ModPath, Map<CompactString, TypeDef>>,
 }
 
 impl<C: Ctx, E: UserEvent> Clone for Env<C, E> {
@@ -204,7 +211,7 @@ impl<C: Ctx, E: UserEvent> Env<C, E> {
         })
     }
 
-    pub fn lookup_typedef(&self, scope: &ModPath, name: &ModPath) -> Option<&Type> {
+    pub fn lookup_typedef(&self, scope: &ModPath, name: &ModPath) -> Option<&TypeDef> {
         self.find_visible(scope, name, |scope, name| {
             self.typedefs.get(scope).and_then(|m| m.get(name))
         })
@@ -258,12 +265,47 @@ impl<C: Ctx, E: UserEvent> Env<C, E> {
         res
     }
 
-    pub fn deftype(&mut self, scope: &ModPath, name: &str, typ: Type) -> Result<()> {
+    pub fn deftype(
+        &mut self,
+        scope: &ModPath,
+        name: &str,
+        params: Arc<[(TVar, Option<Type>)]>,
+        typ: Type,
+    ) -> Result<()> {
         let defs = self.typedefs.get_or_default_cow(scope.clone());
         if defs.get(name).is_some() {
             bail!("{name} is already defined in scope {scope}")
         } else {
-            defs.insert_cow(name.into(), typ);
+            thread_local! {
+                static KNOWN: RefCell<FxHashMap<ArcStr, TVar>> = RefCell::new(FxHashMap::default());
+                static DECLARED: RefCell<FxHashSet<ArcStr>> = RefCell::new(FxHashSet::default());
+            }
+            KNOWN.with_borrow_mut(|known| {
+                known.clear();
+                for (tv, tc) in params.iter() {
+                    Type::TVar(tv.clone()).alias_tvars(known);
+                    if let Some(tc) = tc {
+                        tc.alias_tvars(known);
+                    }
+                }
+                typ.alias_tvars(known);
+            });
+            DECLARED.with_borrow_mut(|declared| {
+                declared.clear();
+                for (tv, _) in params.iter() {
+                    if !declared.insert(tv.name.clone()) {
+                        bail!("duplicate type variable {tv} in definition of {name}");
+                    }
+                }
+                typ.check_tvars_declared(declared)?;
+                for (_, t) in params.iter() {
+                    if let Some(t) = t {
+                        t.check_tvars_declared(declared)?;
+                    }
+                }
+                Ok::<_, anyhow::Error>(())
+            })?;
+            defs.insert_cow(name.into(), TypeDef { params, typ });
             Ok(())
         }
     }

--- a/netidx-bscript/src/expr/mod.rs
+++ b/netidx-bscript/src/expr/mod.rs
@@ -451,7 +451,7 @@ pub enum ExprKind {
     ArraySlice { source: Arc<Expr>, start: Option<Arc<Expr>>, end: Option<Arc<Expr>> },
     StructWith { source: Arc<Expr>, replace: Arc<[(ArcStr, Expr)]> },
     Lambda(Arc<Lambda>),
-    TypeDef { name: ArcStr, typ: Type },
+    TypeDef { name: ArcStr, params: Arc<[(TVar, Option<Type>)]>, typ: Type },
     TypeCast { expr: Arc<Expr>, typ: Type },
     Apply { args: Arc<[(Option<ArcStr>, Expr)]>, function: Arc<Expr> },
     Any { args: Arc<[Expr]> },
@@ -965,7 +965,23 @@ impl fmt::Display for ExprKind {
                 }
             }
             ExprKind::TypeCast { expr, typ } => write!(f, "cast<{typ}>({expr})"),
-            ExprKind::TypeDef { name, typ } => write!(f, "type {name} = {typ}"),
+            ExprKind::TypeDef { name, params, typ } => {
+                write!(f, "type {name}")?;
+                if !params.is_empty() {
+                    write!(f, "<")?;
+                    for (i, (tv, ct)) in params.iter().enumerate() {
+                        write!(f, "{tv}")?;
+                        if let Some(ct) = ct {
+                            write!(f, ": {ct}")?;
+                        }
+                        if i < params.len() - 1 {
+                            write!(f, ", ")?;
+                        }
+                    }
+                    write!(f, ">")?;
+                }
+                write!(f, " = {typ}")
+            }
             ExprKind::Do { exprs } => print_exprs(f, &**exprs, "{", "}", "; "),
             ExprKind::Lambda(l) => {
                 let Lambda { args, vargs, rtype, constraints, body } = &**l;

--- a/netidx-bscript/src/expr/parser/test.rs
+++ b/netidx-bscript/src/expr/parser/test.rs
@@ -635,6 +635,7 @@ fn select1() {
                 type_predicate: Some(Type::Ref {
                     scope: ModPath::root(),
                     name: ["Foo"].into(),
+                    params: Arc::from_iter([]),
                 }),
                 structure_predicate: StructurePattern::Struct {
                     all: None,
@@ -930,7 +931,7 @@ fn apply_typed_lambda() {
                         pattern: StructurePattern::Bind("b".into()),
                         constraint: Some(Type::Set(Arc::from_iter([
                             Type::Primitive(Typ::Null.into()),
-                            Type::Ref { scope: ModPath::root(), name: ["Number"].into() },
+                            Type::Ref { scope: ModPath::root(), name: ["Number"].into(), params: Arc::from_iter([]) },
                         ]))),
                     },
                 ]),
@@ -1031,6 +1032,7 @@ fn labeled_argument_lambda() {
                         typ: Type::Ref {
                             scope: ModPath::root(),
                             name: ["Number"].into(),
+                            params: Arc::from_iter([]),
                         },
                     },
                     FnArgType {
@@ -1039,11 +1041,11 @@ fn labeled_argument_lambda() {
                     },
                     FnArgType {
                         label: Some(("a".into(), false)),
-                        typ: Type::Ref { scope: ModPath::root(), name: ["Any"].into() },
+                        typ: Type::Ref { scope: ModPath::root(), name: ["Any"].into(), params: Arc::from_iter([]) },
                     },
                     FnArgType {
                         label: None,
-                        typ: Type::Ref { scope: ModPath::root(), name: ["Any"].into() },
+                        typ: Type::Ref { scope: ModPath::root(), name: ["Any"].into(), params: Arc::from_iter([]) },
                     },
                 ]),
                 vargs: None,
@@ -1058,6 +1060,7 @@ fn labeled_argument_lambda() {
                         constraint: Some(Type::Ref {
                             scope: ModPath::root(),
                             name: ["Number"].into(),
+                            params: Arc::from_iter([]),
                         }),
                     },
                     Arg {

--- a/netidx-bscript/src/node/compiler.rs
+++ b/netidx-bscript/src/node/compiler.rs
@@ -411,10 +411,10 @@ pub(super) fn compile<C: Ctx, E: UserEvent>(
             let kind = NodeKind::TypeCast { target: typ, n: Box::new(n) };
             Ok(Node { spec: Box::new(spec), typ: rtyp, kind })
         }
-        Expr { kind: ExprKind::TypeDef { name, typ }, id: _, pos } => {
+        Expr { kind: ExprKind::TypeDef { name, params, typ }, id: _, pos } => {
             let typ = typ.scope_refs(scope);
             ctx.env
-                .deftype(scope, name, typ)
+                .deftype(scope, name, params.clone(), typ)
                 .with_context(|| format!("in typedef at {pos}"))?;
             let name = name.clone();
             let spec = Box::new(spec);

--- a/netidx-bscript/src/node/pattern.rs
+++ b/netidx-bscript/src/node/pattern.rs
@@ -82,8 +82,8 @@ impl StructPatternNode {
             };
         }
         let type_predicate = match type_predicate {
-            Type::Ref { .. } => &type_predicate.lookup_ref(&ctx.env)?.clone(),
-            t => t,
+            Type::Ref { .. } => type_predicate.lookup_ref(&ctx.env)?.clone(),
+            t => t.clone(),
         };
         let t = match &spec {
             StructurePattern::Ignore => Self::Ignore,

--- a/netidx-bscript/src/node/pattern.rs
+++ b/netidx-bscript/src/node/pattern.rs
@@ -82,8 +82,8 @@ impl StructPatternNode {
             };
         }
         let type_predicate = match type_predicate {
-            Type::Ref { .. } => type_predicate.lookup_ref(&ctx.env)?.clone(),
-            t => t.clone(),
+            Type::Ref { .. } => &type_predicate.lookup_ref(&ctx.env)?.clone(),
+            t => t,
         };
         let t = match &spec {
             StructurePattern::Ignore => Self::Ignore,

--- a/netidx-bscript/src/tests.rs
+++ b/netidx-bscript/src/tests.rs
@@ -1002,3 +1002,58 @@ run!(rectypes0, RECTYPES0, |v: Result<&Value>| match v {
     },
     _ => false,
 });
+
+#[cfg(test)]
+const RECTYPES1: &str = r#"
+{
+  type List<'a> = [
+    `Cons('a, List<'a>),
+    `Nil
+  ];
+  let l: List<Any> = `Cons(42, `Cons(3, `Nil));
+  l
+}
+"#;
+
+#[cfg(test)]
+run!(rectypes1, RECTYPES1, |v: Result<&Value>| match v {
+    Ok(Value::Array(a)) => match &a[..] {
+        [Value::String(s), Value::I64(42), Value::Array(a)] if &**s == "Cons" =>
+            match &a[..] {
+                [Value::String(s0), Value::I64(3), Value::String(s1)]
+                    if &**s0 == "Cons" && s1 == "Nil" =>
+                    true,
+                _ => false,
+            },
+        _ => false,
+    },
+    _ => false,
+});
+
+#[cfg(test)]
+const TYPEDEF_TVAR_ERR: &str = r#"
+{
+  type T<'a, 'b> = { foo: 'a, bar: 'b, baz: 'c };
+  0
+}
+"#;
+
+#[cfg(test)]
+run!(typedef_tvar_err, TYPEDEF_TVAR_ERR, |v: Result<&Value>| match v {
+    Err(_) => true,
+    _ => false,
+});
+
+#[cfg(test)]
+const TYPEDEF_TVAR_OK: &str = r#"
+{
+  type T<'a, 'b> = { foo: 'a, bar: 'b, f: fn('a, 'b, 'c) -> 'a };
+  0
+}
+"#;
+
+#[cfg(test)]
+run!(typedef_tvar_ok, TYPEDEF_TVAR_OK, |v: Result<&Value>| match v {
+    Ok(Value::I64(0)) => true,
+    _ => false,
+});

--- a/netidx-bscript/src/typ/mod.rs
+++ b/netidx-bscript/src/typ/mod.rs
@@ -127,10 +127,9 @@ impl Type {
                     if let Some(ct) = ct {
                         ct.check_contains(env, arg)?;
                     }
-                    if tv.would_cycle(arg) {
-                        bail!("recursive type parameter for {name}");
+                    if !tv.would_cycle(arg) {
+                        *tv.read().typ.write() = Some(arg.clone());
                     }
-                    *tv.read().typ.write() = Some(arg.clone());
                 }
                 Ok(&def.typ)
             }

--- a/netidx-bscript/src/typ/mod.rs
+++ b/netidx-bscript/src/typ/mod.rs
@@ -65,7 +65,7 @@ pub fn format_with_flags<R, F: FnOnce() -> R>(flags: BitFlags<PrintFlag>, f: F) 
 pub enum Type {
     Bottom,
     Primitive(BitFlags<Typ>),
-    Ref { scope: ModPath, name: ModPath },
+    Ref { scope: ModPath, name: ModPath, params: Arc<[Type]> },
     Fn(Arc<FnType>),
     Set(Arc<[Type]>),
     TVar(TVar),
@@ -110,14 +110,38 @@ impl Type {
         }
     }
 
-    pub fn lookup_ref<'b: 'a, 'a, C: Ctx, E: UserEvent>(
-        &'b self,
+    pub fn lookup_ref<'a, C: Ctx, E: UserEvent>(
+        &'a self,
         env: &'a Env<C, E>,
     ) -> Result<&'a Type> {
         match self {
-            Self::Ref { scope, name } => env
-                .lookup_typedef(scope, name)
-                .ok_or_else(|| anyhow!("undefined type {scope}::{name}")),
+            Self::Ref { scope, name, params } => {
+                let def = env
+                    .lookup_typedef(scope, name)
+                    .ok_or_else(|| anyhow!("undefined type {scope}::{name}"))?;
+                if def.params.len() != params.len() {
+                    bail!("{} expects {} type parameters", name, def.params.len());
+                }
+                def.typ.unbind_tvars();
+                for ((_tv, ct), arg) in def.params.iter().zip(params.iter()) {
+                    let def_ct;
+                    let ct = match ct {
+                        Some(t) => t,
+                        None => {
+                            def_ct = Type::Primitive(Typ::any());
+                            &def_ct
+                        }
+                    };
+                    ct.check_contains(env, arg)?;
+                }
+                for ((tv, _), arg) in def.params.iter().zip(params.iter()) {
+                    if tv.would_cycle(arg) {
+                        bail!("recursive type parameter for {name}");
+                    }
+                    *tv.read().typ.write() = Some(arg.clone());
+                }
+                Ok(&def.typ)
+            }
             t => Ok(t),
         }
     }
@@ -143,7 +167,7 @@ impl Type {
         t: &Self,
     ) -> Result<bool> {
         match (self, t) {
-            (Self::Ref { scope: s0, name: n0 }, Self::Ref { scope: s1, name: n1 })
+            (Self::Ref { scope: s0, name: n0, .. }, Self::Ref { scope: s1, name: n1, .. })
                 if s0 == s1 && n0 == n1 =>
             {
                 Ok(true)
@@ -436,7 +460,7 @@ impl Type {
         t: &Self,
     ) -> Result<Self> {
         match (self, t) {
-            (Type::Ref { scope: s0, name: n0 }, Type::Ref { scope: s1, name: n1 })
+            (Type::Ref { scope: s0, name: n0, .. }, Type::Ref { scope: s1, name: n1, .. })
                 if s0 == s1 && n0 == n1 =>
             {
                 Ok(Type::Primitive(BitFlags::empty()))
@@ -451,7 +475,7 @@ impl Type {
                     None => {
                         let r = Type::Primitive(BitFlags::empty());
                         hist.insert((t0_addr, t1_addr), r);
-                        match t0.diff_int(env, hist, t1) {
+                        match t0.diff_int(env, hist, &t1) {
                             Ok(r) => {
                                 hist.insert((t0_addr, t1_addr), r.clone());
                                 Ok(r)
@@ -601,7 +625,11 @@ impl Type {
     pub fn alias_tvars(&self, known: &mut FxHashMap<ArcStr, TVar>) {
         match self {
             Type::Bottom | Type::Primitive(_) => (),
-            Type::Ref { .. } => (),
+            Type::Ref { params, .. } => {
+                for t in params.iter() {
+                    t.alias_tvars(known);
+                }
+            }
             Type::Array(t) => t.alias_tvars(known),
             Type::Tuple(ts) => {
                 for t in ts.iter() {
@@ -637,7 +665,11 @@ impl Type {
     pub fn collect_tvars(&self, known: &mut FxHashMap<ArcStr, TVar>) {
         match self {
             Type::Bottom | Type::Primitive(_) => (),
-            Type::Ref { .. } => (),
+            Type::Ref { params, .. } => {
+                for t in params.iter() {
+                    t.collect_tvars(known);
+                }
+            }
             Type::Array(t) => t.collect_tvars(known),
             Type::Tuple(ts) => {
                 for t in ts.iter() {
@@ -667,6 +699,26 @@ impl Type {
                     typ.collect_tvars(known)
                 }
             }
+        }
+    }
+
+    pub fn check_tvars_declared(&self, declared: &FxHashSet<ArcStr>) -> Result<()> {
+        match self {
+            Type::Bottom | Type::Primitive(_) => Ok(()),
+            Type::Ref { params, .. } => params.iter().try_for_each(|t| t.check_tvars_declared(declared)),
+            Type::Array(t) => t.check_tvars_declared(declared),
+            Type::Tuple(ts) => ts.iter().try_for_each(|t| t.check_tvars_declared(declared)),
+            Type::Struct(ts) => ts.iter().try_for_each(|(_, t)| t.check_tvars_declared(declared)),
+            Type::Variant(_, ts) => ts.iter().try_for_each(|t| t.check_tvars_declared(declared)),
+            Type::TVar(tv) => {
+                if !declared.contains(&tv.name) {
+                    bail!("undeclared type variable '{}'", tv.name)
+                } else {
+                    Ok(())
+                }
+            }
+            Type::Set(s) => s.iter().try_for_each(|t| t.check_tvars_declared(declared)),
+            Type::Fn(_) => Ok(()),
         }
     }
 
@@ -727,7 +779,11 @@ impl Type {
         match self {
             Type::Bottom => Type::Bottom,
             Type::Primitive(p) => Type::Primitive(*p),
-            Type::Ref { .. } => self.clone(),
+            Type::Ref { scope, name, params } => Type::Ref {
+                scope: scope.clone(),
+                name: name.clone(),
+                params: Arc::from_iter(params.iter().map(|t| t.reset_tvars())),
+            },
             Type::Array(t0) => Type::Array(Arc::new(t0.reset_tvars())),
             Type::Tuple(ts) => {
                 Type::Tuple(Arc::from_iter(ts.iter().map(|t| t.reset_tvars())))
@@ -755,7 +811,11 @@ impl Type {
             },
             Type::Bottom => Type::Bottom,
             Type::Primitive(p) => Type::Primitive(*p),
-            Type::Ref { .. } => self.clone(),
+            Type::Ref { scope, name, params } => Type::Ref {
+                scope: scope.clone(),
+                name: name.clone(),
+                params: Arc::from_iter(params.iter().map(|t| t.replace_tvars(known))),
+            },
             Type::Array(t0) => Type::Array(Arc::new(t0.replace_tvars(known))),
             Type::Tuple(ts) => {
                 Type::Tuple(Arc::from_iter(ts.iter().map(|t| t.replace_tvars(known))))
@@ -1263,9 +1323,12 @@ impl Type {
 
     fn merge(&self, t: &Self) -> Option<Self> {
         match (self, t) {
-            (Type::Ref { scope: s0, name: r0 }, Type::Ref { scope: s1, name: r1 }) => {
-                if s0 == s1 && r0 == r1 {
-                    Some(Type::Ref { scope: s0.clone(), name: r0.clone() })
+            (
+                Type::Ref { scope: s0, name: r0, params: a0 },
+                Type::Ref { scope: s1, name: r1, params: a1 },
+            ) => {
+                if s0 == s1 && r0 == r1 && a0 == a1 {
+                    Some(Type::Ref { scope: s0.clone(), name: r0.clone(), params: a0.clone() })
                 } else {
                     None
                 }
@@ -1400,8 +1463,9 @@ impl Type {
                     Type::TVar(TVar::named(tv.name.clone(), typ))
                 }
             },
-            Type::Ref { scope: _, name } => {
-                Type::Ref { scope: scope.clone(), name: name.clone() }
+            Type::Ref { scope: _, name, params } => {
+                let params = Arc::from_iter(params.iter().map(|t| t.scope_refs(scope)));
+                Type::Ref { scope: scope.clone(), name: name.clone(), params }
             }
             Type::Set(ts) => {
                 Type::Set(Arc::from_iter(ts.iter().map(|t| t.scope_refs(scope))))
@@ -1434,7 +1498,20 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Bottom => write!(f, "_"),
-            Self::Ref { scope: _, name } => write!(f, "{name}"),
+            Self::Ref { scope: _, name, params } => {
+                write!(f, "{name}")?;
+                if !params.is_empty() {
+                    write!(f, "<")?;
+                    for (i, t) in params.iter().enumerate() {
+                        write!(f, "{t}")?;
+                        if i < params.len() - 1 {
+                            write!(f, ", ")?;
+                        }
+                    }
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
             Self::TVar(tv) => write!(f, "{tv}"),
             Self::Fn(t) => write!(f, "{t}"),
             Self::Array(t) => write!(f, "Array<{t}>"),


### PR DESCRIPTION
## Summary
- support type definitions with parameters and enforce declaration of type variables
- parse generics in type references and typedef syntax
- check constraints when instantiating typedefs
- extend recursive type tests
- address review comments

## Testing
- `cargo test -p netidx-bscript --tests` *(fails: failed to build `libgssapi-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_684336359294832fa301b3a744252631