### PR TITLE
Add ByRef/Deref parser steps

### DIFF
--- a/netidx-bscript/src/expr/mod.rs
+++ b/netidx-bscript/src/expr/mod.rs
@@ -461,6 +461,8 @@ pub enum ExprKind {
     Struct { args: Arc<[(ArcStr, Expr)]> },
     Select { arg: Arc<Expr>, arms: Arc<[(Pattern, Expr)]> },
     Qop(Arc<Expr>),
+    ByRef(Arc<Expr>),
+    Deref(Arc<Expr>),
     Eq { lhs: Arc<Expr>, rhs: Arc<Expr> },
     Ne { lhs: Arc<Expr>, rhs: Arc<Expr> },
     Lt { lhs: Arc<Expr>, rhs: Arc<Expr> },
@@ -822,6 +824,20 @@ impl ExprKind {
                     }
                 }
             }
+            ExprKind::ByRef(e) => {
+                try_single_line!(true);
+                writeln!(buf, "&(")?;
+                e.kind.pretty_print(indent + 2, limit, true, buf)?;
+                push_indent(indent, buf);
+                writeln!(buf, ")")
+            }
+            ExprKind::Deref(e) => {
+                try_single_line!(true);
+                writeln!(buf, "*(")?;
+                e.kind.pretty_print(indent + 2, limit, true, buf)?;
+                push_indent(indent, buf);
+                writeln!(buf, ")")
+            }
             ExprKind::Select { arg, arms } => {
                 try_single_line!(true);
                 write!(buf, "select ")?;
@@ -1141,6 +1157,8 @@ impl fmt::Display for ExprKind {
             ExprKind::Sub { lhs, rhs } => write_binop(f, "-", lhs, rhs),
             ExprKind::Mul { lhs, rhs } => write_binop(f, "*", lhs, rhs),
             ExprKind::Div { lhs, rhs } => write_binop(f, "/", lhs, rhs),
+            ExprKind::ByRef(e) => write!(f, "&{e}"),
+            ExprKind::Deref(e) => write!(f, "*{e}"),
             ExprKind::Not { expr } => {
                 write!(f, "(!{expr})")
             }
@@ -1331,7 +1349,10 @@ impl Expr {
                     e.fold(init, f)
                 })
             }
-            ExprKind::Qop(e) | ExprKind::Not { expr: e } => e.fold(init, f),
+            ExprKind::Qop(e)
+            | ExprKind::ByRef(e)
+            | ExprKind::Deref(e)
+            | ExprKind::Not { expr: e } => e.fold(init, f),
             ExprKind::Add { lhs, rhs }
             | ExprKind::Sub { lhs, rhs }
             | ExprKind::Mul { lhs, rhs }
@@ -1663,6 +1684,14 @@ impl Expr {
             ExprKind::Qop(e) => Box::pin(async move {
                 let e = e.resolve_modules(scope, resolvers).await?;
                 Ok(Expr { id: self.id, pos: self.pos, kind: ExprKind::Qop(Arc::new(e)) })
+            }),
+            ExprKind::ByRef(e) => Box::pin(async move {
+                let e = e.resolve_modules(scope, resolvers).await?;
+                Ok(Expr { id: self.id, pos: self.pos, kind: ExprKind::ByRef(Arc::new(e)) })
+            }),
+            ExprKind::Deref(e) => Box::pin(async move {
+                let e = e.resolve_modules(scope, resolvers).await?;
+                Ok(Expr { id: self.id, pos: self.pos, kind: ExprKind::Deref(Arc::new(e)) })
             }),
             ExprKind::Not { expr: e } => Box::pin(async move {
                 let e = e.resolve_modules(scope, resolvers).await?;

--- a/netidx-bscript/src/expr/mod.rs
+++ b/netidx-bscript/src/expr/mod.rs
@@ -826,17 +826,13 @@ impl ExprKind {
             }
             ExprKind::ByRef(e) => {
                 try_single_line!(true);
-                writeln!(buf, "&(")?;
-                e.kind.pretty_print(indent + 2, limit, true, buf)?;
-                push_indent(indent, buf);
-                writeln!(buf, ")")
+                write!(buf, "&")?;
+                e.kind.pretty_print(indent + 2, limit, false, buf)
             }
             ExprKind::Deref(e) => {
                 try_single_line!(true);
-                writeln!(buf, "*(")?;
-                e.kind.pretty_print(indent + 2, limit, true, buf)?;
-                push_indent(indent, buf);
-                writeln!(buf, ")")
+                write!(buf, "*")?;
+                e.kind.pretty_print(indent + 2, limit, false, buf)
             }
             ExprKind::Select { arg, arms } => {
                 try_single_line!(true);
@@ -1687,11 +1683,19 @@ impl Expr {
             }),
             ExprKind::ByRef(e) => Box::pin(async move {
                 let e = e.resolve_modules(scope, resolvers).await?;
-                Ok(Expr { id: self.id, pos: self.pos, kind: ExprKind::ByRef(Arc::new(e)) })
+                Ok(Expr {
+                    id: self.id,
+                    pos: self.pos,
+                    kind: ExprKind::ByRef(Arc::new(e)),
+                })
             }),
             ExprKind::Deref(e) => Box::pin(async move {
                 let e = e.resolve_modules(scope, resolvers).await?;
-                Ok(Expr { id: self.id, pos: self.pos, kind: ExprKind::Deref(Arc::new(e)) })
+                Ok(Expr {
+                    id: self.id,
+                    pos: self.pos,
+                    kind: ExprKind::Deref(Arc::new(e)),
+                })
             }),
             ExprKind::Not { expr: e } => Box::pin(async move {
                 let e = e.resolve_modules(scope, resolvers).await?;

--- a/netidx-bscript/src/expr/parser/mod.rs
+++ b/netidx-bscript/src/expr/parser/mod.rs
@@ -724,6 +724,7 @@ where
     I::Range: Range,
 {
     choice((
+        attempt(sptoken('&').with(typexp()).map(|t| Type::ByRef(Arc::new(t)))),
         attempt(sptoken('_').map(|_| Type::Bottom)),
         attempt(
             between(sptoken('['), sptoken(']'), sep_by(typexp(), csep()))

--- a/netidx-bscript/src/expr/parser/mod.rs
+++ b/netidx-bscript/src/expr/parser/mod.rs
@@ -341,6 +341,8 @@ where
                         | (Some(Expr { kind: ExprKind::ArrayRef { .. }, .. }), _)
                         | (Some(Expr { kind: ExprKind::ArraySlice { .. }, .. }), _)
                         | (Some(Expr { kind: ExprKind::Apply { .. }, .. }), _)
+                        | (Some(Expr { kind: ExprKind::ByRef(_), .. }), _)
+                        | (Some(Expr { kind: ExprKind::Deref(_), .. }), _)
                         | (Some(Expr { kind: ExprKind::Lambda { .. }, .. }), _) => {
                             unreachable!()
                         }
@@ -1482,6 +1484,12 @@ where
         attempt(spaces().with(typedef())),
         attempt(spaces().with(raw_string())),
         attempt(spaces().with(array())),
+        attempt(choice((
+            (position(), sptoken('&').with(expr()))
+                .map(|(pos, expr)| ExprKind::ByRef(Arc::new(expr)).to_expr(pos)),
+            (position(), sptoken('*').with(expr()))
+                .map(|(pos, expr)| ExprKind::Deref(Arc::new(expr)).to_expr(pos)),
+        ))),
         attempt(spaces().with(arith())),
         attempt(spaces().with(tuple())),
         attempt(spaces().with(structure())),

--- a/netidx-bscript/src/expr/test.rs
+++ b/netidx-bscript/src/expr/test.rs
@@ -586,6 +586,18 @@ macro_rules! structwith {
     };
 }
 
+macro_rules! byref {
+    ($inner:expr) => {
+        $inner.prop_map(|e| ExprKind::ByRef(Arc::new(e)).to_expr_nopos())
+    };
+}
+
+macro_rules! deref {
+    ($inner:expr) => {
+        $inner.prop_map(|e| ExprKind::Deref(Arc::new(e)).to_expr_nopos())
+    };
+}
+
 macro_rules! inlinemodule {
     ($inner:expr) => {
         (any::<bool>(), random_fname(), collection::vec($inner, (0, 10))).prop_map(
@@ -630,6 +642,8 @@ fn arithexpr() -> impl Strategy<Value = Expr> {
             inner
                 .clone()
                 .prop_map(|e0| ExprKind::Not { expr: Arc::new(e0) }.to_expr_nopos()),
+            byref!(inner.clone()),
+            deref!(inner.clone()),
             binop!(inner.clone(), Add),
             binop!(inner.clone(), Sub),
             binop!(inner.clone(), Mul),

--- a/netidx-bscript/src/expr/test.rs
+++ b/netidx-bscript/src/expr/test.rs
@@ -1152,6 +1152,8 @@ fn check(s0: &Expr, s1: &Expr) -> bool {
         (ExprKind::Any { args: a0 }, ExprKind::Any { args: a1 }) => {
             a0.len() == a1.len() && a0.iter().zip(a1.iter()).all(|(a0, a1)| check(a0, a1))
         }
+        (ExprKind::ByRef(e0), ExprKind::ByRef(e1)) => check(e0, e1),
+        (ExprKind::Deref(e0), ExprKind::Deref(e1)) => check(e0, e1),
         (_, _) => false,
     }
 }

--- a/netidx-bscript/src/expr/test.rs
+++ b/netidx-bscript/src/expr/test.rs
@@ -227,6 +227,7 @@ fn typexp() -> impl Strategy<Value = Type> {
                 }
             ),
             inner.clone().prop_map(|t| Type::Array(Arc::new(t))),
+            inner.clone().prop_map(|t| Type::ByRef(Arc::new(t))),
             (typath(), collection::vec(inner.clone(), (0, 8))).prop_map(
                 |(name, params)| {
                     Type::Ref { scope: ModPath::root(), name, params: Arc::from(params) }

--- a/netidx-bscript/src/lib.rs
+++ b/netidx-bscript/src/lib.rs
@@ -44,6 +44,12 @@ mod tests;
 atomic_id!(BindId);
 atomic_id!(LambdaId);
 
+impl BindId {
+    pub(crate) fn from_u64(v: u64) -> Self {
+        BindId(v)
+    }
+}
+
 #[macro_export]
 macro_rules! errf {
     ($pat:expr, $($arg:expr),*) => {

--- a/netidx-bscript/src/node/compiler.rs
+++ b/netidx-bscript/src/node/compiler.rs
@@ -2,7 +2,7 @@ use super::{
     callsite::CallSite, lambda::Lambda, select::Select, Add, And, Any, Array, ArrayRef,
     ArraySlice, Bind, Block, Connect, Constant, Div, Eq, Gt, Gte, Lt, Lte, Mul, Ne, Not,
     Or, Qop, Ref, StringInterpolate, Struct, StructRef, StructWith, Sub, Tuple, TupleRef,
-    TypeCast, TypeDef, Use, Variant,
+    TypeCast, TypeDef, Use, Variant, ByRef, Deref,
 };
 use crate::{
     expr::{Expr, ExprId, ExprKind, ModPath, ModuleKind},
@@ -86,6 +86,12 @@ pub(crate) fn compile<C: Ctx, E: UserEvent>(
         }
         Expr { kind: ExprKind::Qop(e), id: _, pos } => {
             Qop::compile(ctx, spec.clone(), scope, top_id, e, pos)
+        }
+        Expr { kind: ExprKind::ByRef(e), id: _, pos: _ } => {
+            ByRef::compile(ctx, spec.clone(), scope, top_id, e)
+        }
+        Expr { kind: ExprKind::Deref(e), id: _, pos: _ } => {
+            Deref::compile(ctx, spec.clone(), scope, top_id, e)
         }
         Expr { kind: ExprKind::Ref { name }, id: _, pos } => {
             Ref::compile(ctx, spec.clone(), scope, top_id, name, pos)

--- a/netidx-bscript/src/node/mod.rs
+++ b/netidx-bscript/src/node/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     env, err,
     expr::{self, Expr, ExprId, ExprKind, ModPath},
-    typ::{TVar, Type},
+    typ::{self, TVar, Type},
     BindId, Ctx, Event, ExecCtx, Node, Update, UserEvent,
 };
 use anyhow::{anyhow, bail, Context, Result};
@@ -584,9 +584,9 @@ impl<C: Ctx, E: UserEvent> Bind<C, E> {
                 let typ = node.typ().clone();
                 let ptyp = pattern.infer_type_predicate();
                 if !ptyp.contains(&ctx.env, &typ)? {
-                    if !matches!(typ, Type::ByRef(_)) {
-                        bail!("at {pos} match error {typ} can't be matched by {ptyp}");
-                    }
+                    typ::format_with_flags(typ::PrintFlag::DerefTVars.into(), || {
+                        bail!("at {pos} match error {typ} can't be matched by {ptyp}")
+                    })?
                 }
                 typ
             }

--- a/netidx-bscript/src/node/pattern.rs
+++ b/netidx-bscript/src/node/pattern.rs
@@ -489,6 +489,7 @@ impl<C: Ctx, E: UserEvent> PatternNode<C, E> {
             | Type::Set(_)
             | Type::TVar(_)
             | Type::Array(_)
+            | Type::ByRef(_)
             | Type::Tuple(_)
             | Type::Variant(_, _)
             | Type::Struct(_)

--- a/netidx-bscript/src/node/pattern.rs
+++ b/netidx-bscript/src/node/pattern.rs
@@ -539,6 +539,7 @@ impl<C: Ctx, E: UserEvent> PatternNode<C, E> {
             | (Type::Tuple(_), Typ::Array)
             | (Type::Struct(_), Typ::Array)
             | (Type::Variant(_, _), Typ::Array | Typ::String) => true,
+            (Type::ByRef(_), Typ::U64) => true,
             _ => self
                 .type_predicate
                 .contains(env, &Type::Primitive(typ.into()))

--- a/netidx-bscript/src/tests.rs
+++ b/netidx-bscript/src/tests.rs
@@ -1075,3 +1075,32 @@ run!(typedef_tvar_ok, TYPEDEF_TVAR_OK, |v: Result<&Value>| match v {
     Ok(Value::I64(0)) => true,
     _ => false,
 });
+
+#[cfg(test)]
+const BYREF_DEREF: &str = r#"
+{
+  let x = &42;
+  *x
+}
+"#;
+
+#[cfg(test)]
+run!(byref_deref, BYREF_DEREF, |v: Result<&Value>| match v {
+    Ok(Value::I64(42)) => true,
+    _ => false,
+});
+
+#[cfg(test)]
+const BYREF_TUPLE: &str = r#"
+{
+  let r = &(1, 2);
+  let t = *r;
+  t.0 + t.1
+}
+"#;
+
+#[cfg(test)]
+run!(byref_tuple, BYREF_TUPLE, |v: Result<&Value>| match v {
+    Ok(Value::I64(3)) => true,
+    _ => false,
+});

--- a/netidx-bscript/src/tests.rs
+++ b/netidx-bscript/src/tests.rs
@@ -1104,3 +1104,19 @@ run!(byref_tuple, BYREF_TUPLE, |v: Result<&Value>| match v {
     Ok(Value::I64(3)) => true,
     _ => false,
 });
+
+#[cfg(test)]
+const BYREF_PATTERN: &str = r#"
+{
+  let r = &42;
+  select r as &i64 {
+    _ => 1
+  }
+}
+"#;
+
+#[cfg(test)]
+run!(byref_pattern, BYREF_PATTERN, |v: Result<&Value>| match v {
+    Ok(Value::I64(1)) => true,
+    _ => false,
+});

--- a/netidx-bscript/src/tests.rs
+++ b/netidx-bscript/src/tests.rs
@@ -1109,14 +1109,14 @@ run!(byref_tuple, BYREF_TUPLE, |v: Result<&Value>| match v {
 const BYREF_PATTERN: &str = r#"
 {
   let r = &42;
-  select r as &i64 {
-    _ => 1
+  select r {
+    &i64 as v => *v
   }
 }
 "#;
 
 #[cfg(test)]
 run!(byref_pattern, BYREF_PATTERN, |v: Result<&Value>| match v {
-    Ok(Value::I64(1)) => true,
+    Ok(Value::I64(42)) => true,
     _ => false,
 });

--- a/netidx-bscript/src/typ/mod.rs
+++ b/netidx-bscript/src/typ/mod.rs
@@ -70,6 +70,7 @@ pub enum Type {
     Set(Arc<[Type]>),
     TVar(TVar),
     Array(Arc<Type>),
+    ByRef(Arc<Type>),
     Tuple(Arc<[Type]>),
     Struct(Arc<[(ArcStr, Type)]>),
     Variant(ArcStr, Arc<[Type]>),
@@ -102,6 +103,7 @@ impl Type {
             | Self::Fn(_)
             | Self::Set(_)
             | Self::Array(_)
+            | Self::ByRef(_)
             | Self::Tuple(_)
             | Self::Struct(_)
             | Self::Variant(_, _) => true,
@@ -228,6 +230,8 @@ impl Type {
                     .map(|(t0, t1)| t0.contains_int(env, hist, t1))
                     .collect::<Result<AndAc>>()?
                     .0),
+            (Self::ByRef(t0), Self::ByRef(t1)) => t0.contains_int(env, hist, t1),
+            (Self::ByRef(_), _) | (_, Self::ByRef(_)) => Ok(false),
             (Self::Tuple(_), Self::Array(_))
             | (Self::Tuple(_), Self::Primitive(_))
             | (Self::Tuple(_), Self::Struct(_))
@@ -373,6 +377,13 @@ impl Type {
                     Type::Set(Arc::from_iter([u.clone(), t.clone()]))
                 }
             }
+            (t @ Type::ByRef(t0), u @ Type::ByRef(t1)) => {
+                if t0 == t1 {
+                    Type::ByRef(t0.clone())
+                } else {
+                    Type::Set(Arc::from_iter([u.clone(), t.clone()]))
+                }
+            }
             (Type::Set(s0), Type::Set(s1)) => {
                 Type::Set(Arc::from_iter(s0.iter().cloned().chain(s1.iter().cloned())))
             }
@@ -432,6 +443,9 @@ impl Type {
             }
             (t0 @ Type::TVar(_), t1) | (t1, t0 @ Type::TVar(_)) => {
                 Type::Set(Arc::from_iter([t0.clone(), t1.clone()]))
+            }
+            (t @ Type::ByRef(_), u) | (u, t @ Type::ByRef(_)) => {
+                Type::Set(Arc::from_iter([t.clone(), u.clone()]))
             }
             (tr @ Type::Ref { .. }, t) | (t, tr @ Type::Ref { .. }) => {
                 Type::Set(Arc::from_iter([tr.clone(), t.clone()]))
@@ -505,6 +519,9 @@ impl Type {
             (Type::Array(t0), Type::Array(t1)) => {
                 Ok(Type::Array(Arc::new(t0.diff_int(env, hist, t1)?)))
             }
+            (Type::ByRef(t0), Type::ByRef(t1)) => {
+                Ok(Type::ByRef(Arc::new(t0.diff_int(env, hist, t1)?)))
+            }
             (Type::Set(s0), Type::Set(s1)) => {
                 let mut s: SmallVec<[Type; 4]> = smallvec![];
                 for i in 0..s0.len() {
@@ -543,6 +560,7 @@ impl Type {
                 }
             }
             (Type::Struct(_), _) | (_, Type::Struct(_)) => Ok(self.clone()),
+            (Type::ByRef(_), _) | (_, Type::ByRef(_)) => Ok(self.clone()),
             (Type::Variant(tg0, t0), Type::Variant(tg1, t1)) => {
                 if tg0 == tg1 && t0.len() == t1.len() && t0 == t1 {
                     Ok(Type::Primitive(BitFlags::empty()))
@@ -620,6 +638,7 @@ impl Type {
                 }
             }
             Type::Array(t) => t.alias_tvars(known),
+            Type::ByRef(t) => t.alias_tvars(known),
             Type::Tuple(ts) => {
                 for t in ts.iter() {
                     t.alias_tvars(known)
@@ -660,6 +679,7 @@ impl Type {
                 }
             }
             Type::Array(t) => t.collect_tvars(known),
+            Type::ByRef(t) => t.collect_tvars(known),
             Type::Tuple(ts) => {
                 for t in ts.iter() {
                     t.collect_tvars(known)
@@ -698,6 +718,7 @@ impl Type {
                 params.iter().try_for_each(|t| t.check_tvars_declared(declared))
             }
             Type::Array(t) => t.check_tvars_declared(declared),
+            Type::ByRef(t) => t.check_tvars_declared(declared),
             Type::Tuple(ts) => {
                 ts.iter().try_for_each(|t| t.check_tvars_declared(declared))
             }
@@ -724,6 +745,7 @@ impl Type {
             Type::Bottom | Type::Primitive(_) => false,
             Type::Ref { .. } => false,
             Type::Array(t0) => t0.has_unbound(),
+            Type::ByRef(t0) => t0.has_unbound(),
             Type::Tuple(ts) => ts.iter().any(|t| t.has_unbound()),
             Type::Struct(ts) => ts.iter().any(|(_, t)| t.has_unbound()),
             Type::Variant(_, ts) => ts.iter().any(|t| t.has_unbound()),
@@ -739,6 +761,7 @@ impl Type {
             Type::Bottom | Type::Primitive(_) => (),
             Type::Ref { .. } => (),
             Type::Array(t0) => t0.bind_as(t),
+            Type::ByRef(t0) => t0.bind_as(t),
             Type::Tuple(ts) => {
                 for elt in ts.iter() {
                     elt.bind_as(t)
@@ -782,6 +805,7 @@ impl Type {
                 params: Arc::from_iter(params.iter().map(|t| t.reset_tvars())),
             },
             Type::Array(t0) => Type::Array(Arc::new(t0.reset_tvars())),
+            Type::ByRef(t0) => Type::ByRef(Arc::new(t0.reset_tvars())),
             Type::Tuple(ts) => {
                 Type::Tuple(Arc::from_iter(ts.iter().map(|t| t.reset_tvars())))
             }
@@ -814,6 +838,7 @@ impl Type {
                 params: Arc::from_iter(params.iter().map(|t| t.replace_tvars(known))),
             },
             Type::Array(t0) => Type::Array(Arc::new(t0.replace_tvars(known))),
+            Type::ByRef(t0) => Type::ByRef(Arc::new(t0.replace_tvars(known))),
             Type::Tuple(ts) => {
                 Type::Tuple(Arc::from_iter(ts.iter().map(|t| t.replace_tvars(known))))
             }
@@ -836,6 +861,7 @@ impl Type {
         match self {
             Type::Bottom | Type::Primitive(_) | Type::Ref { .. } => (),
             Type::Array(t0) => t0.unbind_tvars(),
+            Type::ByRef(t0) => t0.unbind_tvars(),
             Type::Tuple(ts) | Type::Variant(_, ts) | Type::Set(ts) => {
                 for t in ts.iter() {
                     t.unbind_tvars()
@@ -865,7 +891,7 @@ impl Type {
                 tv.read().typ.read().as_ref().and_then(|t| t.first_prim_int(env, hist))
             }
             // array, tuple, and struct casting are handled directly
-            Type::Array(_) | Type::Tuple(_) | Type::Struct(_) | Type::Variant(_, _) => {
+            Type::Array(_) | Type::Tuple(_) | Type::Struct(_) | Type::Variant(_, _) | Type::ByRef(_) => {
                 None
             }
             Type::Ref { .. } => {
@@ -908,6 +934,7 @@ impl Type {
                 None => bail!("can't cast a value to a free type variable"),
             },
             Type::Array(et) => et.check_cast_int(env, hist),
+            Type::ByRef(_) => bail!("can't cast a reference"),
             Type::Tuple(ts) => Ok(for t in ts.iter() {
                 t.check_cast_int(env, hist)?
             }),
@@ -1161,6 +1188,7 @@ impl Type {
                 Value::Array(a) => a.iter().all(|v| et.is_a_int(env, hist, v)),
                 _ => false,
             },
+            Type::ByRef(_) => matches!(v, Value::U64(_) | Value::V64(_)),
             Type::Tuple(ts) => match v {
                 Value::Array(elts) => {
                     elts.len() == ts.len()
@@ -1236,6 +1264,7 @@ impl Type {
             | Type::Ref { .. }
             | Type::Fn(_)
             | Type::Array(_)
+            | Type::ByRef(_)
             | Type::Tuple(_)
             | Type::Struct(_)
             | Type::Variant(_, _)
@@ -1250,6 +1279,7 @@ impl Type {
             | Self::Fn(_)
             | Self::Set(_)
             | Self::Array(_)
+            | Self::ByRef(_)
             | Self::Tuple(_)
             | Self::Struct(_)
             | Self::Variant(_, _)
@@ -1308,6 +1338,7 @@ impl Type {
             Type::TVar(tv) => Type::TVar(tv.normalize()),
             Type::Set(s) => Self::flatten_set(s.iter().map(|t| t.normalize())),
             Type::Array(t) => Type::Array(Arc::new(t.normalize())),
+            Type::ByRef(t) => Type::ByRef(Arc::new(t.normalize())),
             Type::Tuple(t) => {
                 Type::Tuple(Arc::from_iter(t.iter().map(|t| t.normalize())))
             }
@@ -1370,6 +1401,10 @@ impl Type {
                     None
                 }
             }
+            (Type::ByRef(t0), Type::ByRef(t1)) => {
+                t0.merge(t1).map(|t| Type::ByRef(Arc::new(t)))
+            }
+            (Type::ByRef(_), _) | (_, Type::ByRef(_)) => None,
             (Type::Array(_), _) | (_, Type::Array(_)) => None,
             (Type::Set(s0), Type::Set(s1)) => {
                 Some(Self::flatten_set(s0.iter().cloned().chain(s1.iter().cloned())))
@@ -1449,6 +1484,7 @@ impl Type {
             Type::Bottom => Type::Bottom,
             Type::Primitive(s) => Type::Primitive(*s),
             Type::Array(t0) => Type::Array(Arc::new(t0.scope_refs(scope))),
+            Type::ByRef(t) => Type::ByRef(Arc::new(t.scope_refs(scope))),
             Type::Tuple(ts) => {
                 let i = ts.iter().map(|t| t.scope_refs(scope));
                 Type::Tuple(Arc::from_iter(i))
@@ -1520,6 +1556,7 @@ impl fmt::Display for Type {
             Self::TVar(tv) => write!(f, "{tv}"),
             Self::Fn(t) => write!(f, "{t}"),
             Self::Array(t) => write!(f, "Array<{t}>"),
+            Self::ByRef(t) => write!(f, "&{t}"),
             Self::Tuple(ts) => {
                 write!(f, "(")?;
                 for (i, t) in ts.iter().enumerate() {

--- a/netidx-bscript/src/typ/tval.rs
+++ b/netidx-bscript/src/typ/tval.rs
@@ -53,6 +53,7 @@ impl<'a, C: Ctx, E: UserEvent> TVal<'a, C, E> {
                 write!(f, "]")
             }
             (Type::Array(_), v) => write!(f, "{}", NakedValue(v)),
+            (Type::ByRef(_), v) => write!(f, "{}", NakedValue(v)),
             (Type::Struct(flds), Value::Array(a)) => {
                 write!(f, "{{")?;
                 for (i, ((n, et), v)) in flds.iter().zip(a.iter()).enumerate() {

--- a/netidx-bscript/src/typ/tvar.rs
+++ b/netidx-bscript/src/typ/tvar.rs
@@ -26,6 +26,7 @@ pub(super) fn would_cycle_inner(addr: usize, t: &Type) -> bool {
                 }
         }
         Type::Array(a) => would_cycle_inner(addr, &**a),
+        Type::ByRef(t) => would_cycle_inner(addr, t),
         Type::Tuple(ts) => ts.iter().any(|t| would_cycle_inner(addr, t)),
         Type::Variant(_, ts) => ts.iter().any(|t| would_cycle_inner(addr, t)),
         Type::Struct(ts) => ts.iter().any(|(_, t)| would_cycle_inner(addr, t)),


### PR DESCRIPTION
## Summary
- experiment with putting ByRef/Deref in the main expression parser
- expand property tests with ByRef/Deref cases

## Testing
- `cargo test -p netidx-bscript` *(fails: 188 passed; 16 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d3ecdf4832fb67b2ec5bb7806b9