### PR TITLE
Add Chart widget support

### DIFF
--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -6,7 +6,8 @@ mod gui {
     `Block(Block),
     `Scrollbar(Scrollbar),
     `Layout(Layout),
-    `BarChart(BarChart)
+    `BarChart(BarChart),
+    `Chart(Chart)
   ];
 
   type MediaKeyCode = [
@@ -488,5 +489,92 @@ mod gui {
     max,
     style,
     value_style
+  })
+
+  type Marker = [
+    `Dot,
+    `Block,
+    `Bar,
+    `Braille,
+    `HalfBlock
+  ];
+
+  type GraphType = [
+    `Scatter,
+    `Line,
+    `Bar
+  ];
+
+  type LegendPosition = [
+    `Top,
+    `TopRight,
+    `TopLeft,
+    `Left,
+    `Right,
+    `Bottom,
+    `BottomRight,
+    `BottomLeft
+  ];
+
+  type Axis = {
+    bounds: {min: f64, max: f64},
+    labels: [Array<Line>, null],
+    labels_alignment: [Alignment, null],
+    style: [Style, null],
+    title: [Line, null]
+  };
+
+  let axis = |
+    #labels: [Array<Line>, null] = null,
+    #labels_alignment: [Alignment, null] = null,
+    #style: [Style, null] = null,
+    #title: [Line, null] = null,
+    bounds: {min: f64, max: f64}
+  | -> Axis { bounds, labels, labels_alignment, style, title };
+
+  type Dataset = {
+    name: &[Line, null],
+    data: &Array<(f64, f64)>,
+    marker: &[Marker, null],
+    graph_type: &[GraphType, null],
+    style: &[Style, null]
+  };
+
+  let dataset = |
+    #marker: &[Marker, null] = &null,
+    #graph_type: &[GraphType, null] = &null,
+    #name: &[Line, null] = &null,
+    #style: &[Style, null] = &null,
+    data: &Array<(f64, f64)>
+  | -> Dataset { name, data, marker, graph_type, style };
+
+  type LegendConstraints = {
+    width: Constraint,
+    height: Constraint
+  };
+
+  type Chart = {
+    datasets: &Array<Dataset>,
+    hidden_legend_constraints: &[LegendConstraints, null],
+    legend_position: &[LegendPosition, null],
+    style: &[Style, null],
+    x_axis: &[Axis, null],
+    y_axis: &[Axis, null]
+  };
+
+  let chart = |
+    #hidden_legend_constraints: &[LegendConstraints, null] = &null,
+    #legend_position: &[LegendPosition, null] = &null,
+    #style: &[Style, null] = &null,
+    #x_axis: &[Axis, null] = &null,
+    #y_axis: &[Axis, null] = &null,
+    datasets: &Array<Dataset>
+  | -> Gui `Chart({
+    datasets,
+    hidden_legend_constraints,
+    legend_position,
+    style,
+    x_axis,
+    y_axis
   })
 }

--- a/netidx-tools/src/shell/gui/block.rs
+++ b/netidx-tools/src/shell/gui/block.rs
@@ -20,7 +20,7 @@ use smallvec::SmallVec;
 use tokio::try_join;
 
 #[derive(Clone, Copy)]
-struct BordersV(Borders);
+pub(super) struct BordersV(Borders);
 
 impl FromValue for BordersV {
     fn from_value(v: Value) -> Result<Self> {
@@ -48,7 +48,7 @@ impl FromValue for BordersV {
 }
 
 #[derive(Clone, Copy)]
-struct BorderTypeV(BorderType);
+pub(super) struct BorderTypeV(BorderType);
 
 impl FromValue for BorderTypeV {
     fn from_value(v: Value) -> Result<Self> {
@@ -65,7 +65,7 @@ impl FromValue for BorderTypeV {
 }
 
 #[derive(Clone, Copy)]
-struct PaddingV(Padding);
+pub(super) struct PaddingV(Padding);
 
 impl FromValue for PaddingV {
     fn from_value(v: Value) -> Result<Self> {

--- a/netidx-tools/src/shell/gui/chart.rs
+++ b/netidx-tools/src/shell/gui/chart.rs
@@ -1,0 +1,277 @@
+use super::{into_borrowed_line, AlignmentV, GuiW, GuiWidget, LineV, StyleV, TRef,
+    layout::ConstraintV};
+use anyhow::{Context, Result};
+use arcstr::ArcStr;
+use async_trait::async_trait;
+use crossterm::event::Event;
+use futures::future::try_join_all;
+use netidx::publisher::{FromValue, Value};
+use netidx_bscript::{expr::ExprId, rt::{BSHandle, Ref}};
+use ratatui::{
+    layout::{Constraint, Rect},
+    style::Style,
+    text::Line,
+    widgets::{self, Axis, Chart, Dataset, GraphType, LegendPosition},
+    symbols,
+    Frame,
+};
+use smallvec::SmallVec;
+use tokio::try_join;
+
+#[derive(Clone, Copy)]
+struct MarkerV(symbols::Marker);
+
+impl FromValue for MarkerV {
+    fn from_value(v: Value) -> Result<Self> {
+        let m = match &*v.cast_to::<ArcStr>()? {
+            "Dot" => symbols::Marker::Dot,
+            "Block" => symbols::Marker::Block,
+            "Bar" => symbols::Marker::Bar,
+            "Braille" => symbols::Marker::Braille,
+            "HalfBlock" => symbols::Marker::HalfBlock,
+            s => bail!("invalid marker {s}"),
+        };
+        Ok(Self(m))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GraphTypeV(GraphType);
+
+impl FromValue for GraphTypeV {
+    fn from_value(v: Value) -> Result<Self> {
+        let g = match &*v.cast_to::<ArcStr>()? {
+            "Scatter" => GraphType::Scatter,
+            "Line" => GraphType::Line,
+            "Bar" => GraphType::Bar,
+            s => bail!("invalid graphtype {s}"),
+        };
+        Ok(Self(g))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LegendPositionV(LegendPosition);
+
+impl FromValue for LegendPositionV {
+    fn from_value(v: Value) -> Result<Self> {
+        let p = match &*v.cast_to::<ArcStr>()? {
+            "Top" => LegendPosition::Top,
+            "TopRight" => LegendPosition::TopRight,
+            "TopLeft" => LegendPosition::TopLeft,
+            "Left" => LegendPosition::Left,
+            "Right" => LegendPosition::Right,
+            "Bottom" => LegendPosition::Bottom,
+            "BottomRight" => LegendPosition::BottomRight,
+            "BottomLeft" => LegendPosition::BottomLeft,
+            s => bail!("invalid legend position {s}"),
+        };
+        Ok(Self(p))
+    }
+}
+
+#[derive(Clone)]
+struct AxisV(Axis<'static>);
+
+impl FromValue for AxisV {
+    fn from_value(v: Value) -> Result<Self> {
+        let [(_, bounds), (_, labels), (_, labels_alignment), (_, style), (_, title)] =
+            v.cast_to::<[(ArcStr, Value); 5]>()?;
+        let [(_, min), (_, max)] = bounds.cast_to::<[(ArcStr, f64); 2]>()?;
+        let mut axis = Axis::default().bounds([min, max]);
+        if let Some(lbls) = labels.cast_to::<Option<SmallVec<[LineV; 8]>>>()? {
+            let lines = lbls.into_iter().map(|l| into_borrowed_line(&l.0)).collect::<Vec<_>>();
+            axis = axis.labels(lines);
+        }
+        if let Some(al) = labels_alignment.cast_to::<Option<AlignmentV>>()? {
+            axis = axis.labels_alignment(al.0);
+        }
+        if let Some(st) = style.cast_to::<Option<StyleV>>()? {
+            axis = axis.style(st.0);
+        }
+        if let Some(LineV(t)) = title.cast_to::<Option<LineV>>()? {
+            axis = axis.title(into_borrowed_line(&t));
+        }
+        Ok(Self(axis))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HLConstraintsV((Constraint, Constraint));
+
+impl FromValue for HLConstraintsV {
+    fn from_value(v: Value) -> Result<Self> {
+        let [(_, w), (_, h)] = v.cast_to::<[(ArcStr, Value); 2]>()?;
+        let w = w.cast_to::<ConstraintV>()?.0;
+        let h = h.cast_to::<ConstraintV>()?.0;
+        Ok(Self((w, h)))
+    }
+}
+
+
+struct DatasetW {
+    name: TRef<Option<LineV>>,
+    data: TRef<SmallVec<[(f64, f64); 32]>>,
+    marker: TRef<Option<MarkerV>>,
+    graph_type: TRef<Option<GraphTypeV>>,
+    style: TRef<Option<StyleV>>,
+}
+
+impl DatasetW {
+    async fn compile(bs: &BSHandle, v: Value) -> Result<Self> {
+        let [(_, name), (_, data), (_, marker), (_, graph_type), (_, style)] =
+            v.cast_to::<[(ArcStr, Value); 5]>()?;
+        let (name, data, marker, graph_type, style) = try_join! {
+            bs.compile_ref(name),
+            bs.compile_ref(data),
+            bs.compile_ref(marker),
+            bs.compile_ref(graph_type),
+            bs.compile_ref(style)
+        }?;
+        Ok(Self {
+            name: TRef::new(name)?,
+            data: TRef::new(data)?,
+            marker: TRef::new(marker)?,
+            graph_type: TRef::new(graph_type)?,
+            style: TRef::new(style)?,
+        })
+    }
+
+    fn update(&mut self, id: ExprId, v: &Value) -> Result<()> {
+        self.name.update(id, v).context("dataset name update")?;
+        self.data.update(id, v).context("dataset data update")?;
+        self.marker.update(id, v).context("dataset marker update")?;
+        self.graph_type.update(id, v).context("dataset graph_type update")?;
+        self.style.update(id, v).context("dataset style update")?;
+        Ok(())
+    }
+
+    fn build<'a>(&'a self) -> Dataset<'a> {
+        let mut ds = Dataset::default();
+        let data_slice: &[(f64, f64)] = self.data.t.as_ref().map(|d| &d[..]).unwrap_or(&[]);
+        ds = ds.data(data_slice);
+        if let Some(Some(LineV(l))) = &self.name.t {
+            ds = ds.name(into_borrowed_line(l));
+        }
+        if let Some(Some(m)) = self.marker.t {
+            ds = ds.marker(m.0);
+        }
+        if let Some(Some(g)) = self.graph_type.t {
+            ds = ds.graph_type(g.0);
+        }
+        if let Some(Some(s)) = &self.style.t {
+            ds = ds.style(s.0);
+        }
+        ds
+    }
+}
+
+pub(super) struct ChartW {
+    bs: BSHandle,
+    datasets_ref: Ref,
+    datasets: Vec<DatasetW>,
+    hidden: TRef<Option<HLConstraintsV>>,
+    legend: TRef<Option<LegendPositionV>>,
+    style: TRef<Option<StyleV>>,
+    x_axis: TRef<Option<AxisV>>,
+    y_axis: TRef<Option<AxisV>>,
+}
+
+impl ChartW {
+    pub(super) async fn compile(bs: BSHandle, v: Value) -> Result<GuiW> {
+        let [
+            (_, datasets),
+            (_, hidden),
+            (_, legend),
+            (_, style),
+            (_, x_axis),
+            (_, y_axis),
+        ] = v.cast_to::<[(ArcStr, Value); 6]>()?;
+        let (
+            datasets_ref,
+            hidden,
+            legend,
+            style,
+            x_axis,
+            y_axis,
+        ) = try_join! {
+            bs.compile_ref(datasets),
+            bs.compile_ref(hidden),
+            bs.compile_ref(legend),
+            bs.compile_ref(style),
+            bs.compile_ref(x_axis),
+            bs.compile_ref(y_axis)
+        }?;
+        let mut t = Self {
+            bs: bs.clone(),
+            datasets_ref,
+            datasets: vec![],
+            hidden: TRef::new(hidden)?,
+            legend: TRef::new(legend)?,
+            style: TRef::new(style)?,
+            x_axis: TRef::new(x_axis)?,
+            y_axis: TRef::new(y_axis)?,
+        };
+        if let Some(v) = t.datasets_ref.last.take() {
+            t.set_datasets(v).await?;
+        }
+        Ok(Box::new(t))
+    }
+
+    async fn set_datasets(&mut self, v: Value) -> Result<()> {
+        let ds = v
+            .cast_to::<SmallVec<[Value; 8]>>()?
+            .into_iter()
+            .map(|d| DatasetW::compile(&self.bs, d));
+        self.datasets = try_join_all(ds).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl GuiWidget for ChartW {
+    async fn handle_event(&mut self, _e: Event) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle_update(&mut self, id: ExprId, v: Value) -> Result<()> {
+        self.hidden.update(id, &v).context("chart hidden update")?;
+        self.legend.update(id, &v).context("chart legend update")?;
+        self.style.update(id, &v).context("chart style update")?;
+        self.x_axis.update(id, &v).context("chart x_axis update")?;
+        self.y_axis.update(id, &v).context("chart y_axis update")?;
+        if self.datasets_ref.id == id {
+            self.set_datasets(v.clone()).await?;
+        }
+        for d in &mut self.datasets {
+            d.update(id, &v)?;
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, rect: Rect) -> Result<()> {
+        let mut ds: SmallVec<[Dataset; 8]> = SmallVec::new();
+        for d in &self.datasets {
+            ds.push(d.build());
+        }
+        let mut chart = Chart::new(ds.into_vec());
+        if let Some(Some(h)) = &self.hidden.t {
+            chart = chart.hidden_legend_constraints(h.0);
+        }
+        if let Some(Some(p)) = self.legend.t {
+            chart = chart.legend_position(Some(p.0));
+        }
+        if let Some(Some(s)) = &self.style.t {
+            chart = chart.style(s.0);
+        }
+        if let Some(Some(a)) = &self.x_axis.t {
+            chart = chart.x_axis(a.0.clone());
+        }
+        if let Some(Some(a)) = &self.y_axis.t {
+            chart = chart.y_axis(a.0.clone());
+        }
+        frame.render_widget(chart, rect);
+        Ok(())
+    }
+}
+

--- a/netidx-tools/src/shell/gui/layout.rs
+++ b/netidx-tools/src/shell/gui/layout.rs
@@ -17,7 +17,7 @@ use smallvec::SmallVec;
 use tokio::try_join;
 
 #[derive(Clone, Copy)]
-struct ConstraintV(Constraint);
+pub(super) struct ConstraintV(Constraint);
 
 impl FromValue for ConstraintV {
     fn from_value(v: Value) -> Result<Self> {

--- a/netidx-tools/src/shell/gui/mod.rs
+++ b/netidx-tools/src/shell/gui/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use arcstr::ArcStr;
 use async_trait::async_trait;
 use barchart::BarChartW;
+use chart::ChartW;
 use block::BlockW;
 use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers};
 use futures::{channel::mpsc, SinkExt, StreamExt};
@@ -29,6 +30,7 @@ use tokio::{select, sync::oneshot, task};
 
 mod barchart;
 mod block;
+mod chart;
 mod layout;
 mod paragraph;
 mod scrollbar;
@@ -282,6 +284,7 @@ fn compile(bs: BSHandle, source: Value) -> CompRes {
             (s, v) if &s == "Scrollbar" => ScrollbarW::compile(bs, v).await,
             (s, v) if &s == "Layout" => LayoutW::compile(bs, v).await,
             (s, v) if &s == "BarChart" => BarChartW::compile(bs, v).await,
+            (s, v) if &s == "Chart" => ChartW::compile(bs, v).await,
             (s, v) => bail!("invalid widget type `{s}({v})"),
         }
     })


### PR DESCRIPTION
## Summary
- expose more internals in block/layout modules
- add Chart widget types to the bscript interface
- implement Chart widget backend
- revise bscript types per feedback

## Testing
- `cargo check -p netidx-tools --quiet` *(fails: could not compile `netidx-bscript` due to unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_6867b63a0484832f8325d7fb19633830