### PR TITLE
Add Sparkline widget

### DIFF
--- a/netidx-tools/src/shell/examples/chart.bs
+++ b/netidx-tools/src/shell/examples/chart.bs
@@ -15,17 +15,18 @@ let data: Array<(f64, f64)> = {
 };
 
 let ds = dataset(
-  #style: &style(#fg: `Green),
+  #style: &style(#fg: `Cyan),
   #graph_type: &`Line,
   #marker: &`Dot,
   #name: &line("stuff"),
   &data
 );
 
-let label_style = style(#fg: `Cyan);
-let axis_style = style(#fg: `Yellow);
+let label_style = style(#fg: `Yellow);
+let axis_style = style(#fg: `Magenta);
 
 chart(
+  #style: &style(#bg: `Rgb({r: u32:20, g: u32:20, b: u32:20})),
   #x_axis:&axis(
     #title: line(#style: label_style, "Cycle(n)"),
     #style: axis_style,
@@ -40,10 +41,8 @@ chart(
     #title: line(#style: label_style, "Stuff"),
     #style: axis_style,
     #labels: [
-      line(#style: label_style, "0"),
-      line(#style: label_style, "25"),
-      line(#style: label_style, "50"),
-      line(#style: label_style, "75"),
+      line(#style: label_style, "0"), line(#style: label_style, "25"),
+      line(#style: label_style, "50"), line(#style: label_style, "75"),
       line(#style: label_style, "100")
     ],
     {min: 0.0, max: 100.0}

--- a/netidx-tools/src/shell/examples/sparkline.bs
+++ b/netidx-tools/src/shell/examples/sparkline.bs
@@ -4,7 +4,8 @@ use rand;
 let data: Array<[SparklineBar, f64]> = {
   let trigger = time::timer(duration:0.3s, true);
   let v = select rand::rand(#trigger, #start: f64:0., #end: f64:100.) {
-    x if x > 50. => sparkline_bar(#style: style(#fg:`Red), x),
+    x if (x > 50.) && (x < 75.) => sparkline_bar(#style: style(#fg:`Yellow), x),
+    x if x > 75. => sparkline_bar(#style: style(#fg:`Red), x),
     x => x
   };
   let d = [];
@@ -16,9 +17,13 @@ let data: Array<[SparklineBar, f64]> = {
   d
 };
 
-sparkline(
-  #style: &style(#fg: `Cyan),
-  #max: &u64:100,
-  #direction: &`LeftToRight,
-  &data
+block(
+  #border:&`All,
+  #title:&line("Rate"),
+  &sparkline(
+    #style: &style(#fg: `Green),
+    #max: &u64:100,
+    #direction: &`LeftToRight,
+    &data
+  )
 )

--- a/netidx-tools/src/shell/examples/sparkline.bs
+++ b/netidx-tools/src/shell/examples/sparkline.bs
@@ -1,0 +1,20 @@
+use gui;
+use rand;
+
+let data: Array<f64> = {
+  let trigger = time::timer(duration:0.3s, true);
+  let v = rand::rand(#trigger, #start: f64:0., #end: f64:100.);
+  let d = [];
+  d <- array::push(sample(#trigger, d), v);
+  select array::len(d) {
+    u64 as len if len > u64:30 => d <- d[(len - u64:30) .. len]?,
+    _ => never()
+  };
+  d
+};
+
+sparkline(
+  #max: &u64:100,
+  #direction: &`LeftToRight,
+  &data
+)

--- a/netidx-tools/src/shell/examples/sparkline.bs
+++ b/netidx-tools/src/shell/examples/sparkline.bs
@@ -1,19 +1,23 @@
 use gui;
 use rand;
 
-let data: Array<f64> = {
+let data: Array<[SparklineBar, f64]> = {
   let trigger = time::timer(duration:0.3s, true);
-  let v = rand::rand(#trigger, #start: f64:0., #end: f64:100.);
+  let v = select rand::rand(#trigger, #start: f64:0., #end: f64:100.) {
+    x if x > 50. => sparkline_bar(#style: style(#fg:`Red), x),
+    x => x
+  };
   let d = [];
   d <- array::push(sample(#trigger, d), v);
   select array::len(d) {
-    u64 as len if len > u64:30 => d <- d[(len - u64:30) .. len]?,
+    u64 as len if len > u64:80 => d <- d[(len - u64:80) .. len]?,
     _ => never()
   };
   d
 };
 
 sparkline(
+  #style: &style(#fg: `Cyan),
   #max: &u64:100,
   #direction: &`LeftToRight,
   &data

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -577,7 +577,7 @@ mod gui {
     style,
     x_axis,
     y_axis
-  })
+  });
 
   type RenderDirection = [
     `LeftToRight,
@@ -604,14 +604,14 @@ mod gui {
   };
 
   let sparkline = |
-    #absent_value_style: &[Style, null],
-    #absent_value_symbol: &[string, null],
+    #absent_value_style: &[Style, null] = &null,
+    #absent_value_symbol: &[string, null] = &null,
     #direction: &[RenderDirection, null] = &null,
     #max: &[u64, null] = &null,
     #style: &[Style, null] = &null,
     data: &Array<[SparklineBar, f64, null]>
   | -> Gui `Sparkline({
-    absent_value_symbo,
+    absent_value_symbol,
     absent_value_style,
     data,
     direction,

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -595,6 +595,8 @@ mod gui {
   | -> SparklineBar { style, value };
 
   type Sparkline = {
+    absent_value_style: &[Style, null],
+    absent_value_symbol: &[string, null],
     data: &Array<[SparklineBar, f64, null]>,
     direction: &[RenderDirection, null],
     max: &[u64, null],
@@ -602,9 +604,18 @@ mod gui {
   };
 
   let sparkline = |
+    #absent_value_style: &[Style, null],
+    #absent_value_symbol: &[string, null],
     #direction: &[RenderDirection, null] = &null,
     #max: &[u64, null] = &null,
     #style: &[Style, null] = &null,
     data: &Array<[SparklineBar, f64, null]>
-  | -> Gui `Sparkline({ data, direction, max, style })
+  | -> Gui `Sparkline({
+    absent_value_symbo,
+    absent_value_style,
+    data,
+    direction,
+    max,
+    style
+  })
 }

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -7,7 +7,8 @@ mod gui {
     `Scrollbar(Scrollbar),
     `Layout(Layout),
     `BarChart(BarChart),
-    `Chart(Chart)
+    `Chart(Chart),
+    `Sparkline(Sparkline)
   ];
 
   type MediaKeyCode = [
@@ -577,4 +578,33 @@ mod gui {
     x_axis,
     y_axis
   })
+
+  type RenderDirection = [
+    `LeftToRight,
+    `RightToLeft
+  ];
+
+  type SparklineBar = {
+    style: [Style, null],
+    value: [f64, null]
+  };
+
+  let sparkline_bar = |
+    #style: [Style, null] = null,
+    value: [f64, null]
+  | -> SparklineBar { style, value };
+
+  type Sparkline = {
+    data: &Array<[SparklineBar, f64, null]>,
+    direction: &[RenderDirection, null],
+    max: &[u64, null],
+    style: &[Style, null]
+  };
+
+  let sparkline = |
+    #direction: &[RenderDirection, null] = &null,
+    #max: &[u64, null] = &null,
+    #style: &[Style, null] = &null,
+    data: &Array<[SparklineBar, f64, null]>
+  | -> Gui `Sparkline({ data, direction, max, style })
 }

--- a/netidx-tools/src/shell/gui/mod.rs
+++ b/netidx-tools/src/shell/gui/mod.rs
@@ -23,6 +23,7 @@ use ratatui::{
 };
 use reedline::Signal;
 use scrollbar::ScrollbarW;
+use sparkline::SparklineW;
 use smallvec::SmallVec;
 use std::{borrow::Cow, future::Future, pin::Pin};
 use text::TextW;
@@ -35,6 +36,7 @@ mod layout;
 mod paragraph;
 mod scrollbar;
 mod text;
+mod sparkline;
 
 #[derive(Clone, Copy)]
 struct AlignmentV(Alignment);
@@ -285,6 +287,7 @@ fn compile(bs: BSHandle, source: Value) -> CompRes {
             (s, v) if &s == "Layout" => LayoutW::compile(bs, v).await,
             (s, v) if &s == "BarChart" => BarChartW::compile(bs, v).await,
             (s, v) if &s == "Chart" => ChartW::compile(bs, v).await,
+            (s, v) if &s == "Sparkline" => SparklineW::compile(bs, v).await,
             (s, v) => bail!("invalid widget type `{s}({v})"),
         }
     })

--- a/netidx-tools/src/shell/gui/sparkline.rs
+++ b/netidx-tools/src/shell/gui/sparkline.rs
@@ -1,0 +1,135 @@
+use super::{GuiW, GuiWidget, StyleV, TRef};
+use anyhow::{bail, Context, Result};
+use arcstr::ArcStr;
+use async_trait::async_trait;
+use crossterm::event::Event;
+use netidx::publisher::{FromValue, Value};
+use netidx_bscript::{expr::ExprId, rt::{BSHandle, Ref}};
+use ratatui::{
+    layout::Rect,
+    widgets::{RenderDirection, Sparkline, SparklineBar},
+    Frame,
+};
+use tokio::try_join;
+
+#[derive(Clone, Copy)]
+struct RenderDirectionV(RenderDirection);
+
+impl FromValue for RenderDirectionV {
+    fn from_value(v: Value) -> Result<Self> {
+        match &*v.cast_to::<ArcStr>()? {
+            "LeftToRight" => Ok(Self(RenderDirection::LeftToRight)),
+            "RightToLeft" => Ok(Self(RenderDirection::RightToLeft)),
+            s => bail!("invalid render direction {s}"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SparklineBarV(SparklineBar);
+
+impl FromValue for SparklineBarV {
+    fn from_value(v: Value) -> Result<Self> {
+        match v {
+            Value::Array(_) => {
+                let [(_, style), (_, value)] = v.cast_to::<[(ArcStr, Value); 2]>()?;
+                let style = style.cast_to::<Option<StyleV>>()?.map(|s| s.0);
+                let value = value
+                    .cast_to::<Option<f64>>()?
+                    .map(|v| v as u64);
+                Ok(Self(SparklineBar { value, style }))
+            }
+            v => {
+                let value = v.cast_to::<Option<f64>>()?.map(|v| v as u64);
+                Ok(Self(SparklineBar::from(value)))
+            }
+        }
+    }
+}
+
+pub(super) struct SparklineW {
+    bs: BSHandle,
+    data_ref: Ref,
+    data: Vec<SparklineBar>,
+    direction: TRef<Option<RenderDirectionV>>,
+    max: TRef<Option<u64>>,
+    style: TRef<Option<StyleV>>,
+}
+
+impl SparklineW {
+    pub(super) async fn compile(bs: BSHandle, v: Value) -> Result<GuiW> {
+        let [(_, data), (_, direction), (_, max), (_, style)] =
+            v.cast_to::<[(ArcStr, Value); 4]>()?;
+        let (data_ref, direction, max, style) = try_join! {
+            bs.compile_ref(data),
+            bs.compile_ref(direction),
+            bs.compile_ref(max),
+            bs.compile_ref(style),
+        }?;
+        let mut t = Self {
+            bs: bs.clone(),
+            data_ref,
+            data: vec![],
+            direction: TRef::new(direction)?,
+            max: TRef::new(max)?,
+            style: TRef::new(style)?,
+        };
+        if let Some(v) = t.data_ref.last.take() {
+            t.set_data(&v)?;
+        }
+        Ok(Box::new(t))
+    }
+
+    fn set_data(&mut self, v: &Value) -> Result<()> {
+        self.data.clear();
+        match v {
+            Value::Array(a) => {
+                for v in a {
+                    self.data.push(v.clone().cast_to::<SparklineBarV>()?.0);
+                }
+            }
+            v => bail!("invalid sparkline data {v}"),
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl GuiWidget for SparklineW {
+    async fn handle_event(&mut self, _e: Event) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle_update(&mut self, id: ExprId, v: Value) -> Result<()> {
+        let Self {
+            bs: _,
+            data_ref,
+            data: _,
+            direction,
+            max,
+            style,
+        } = self;
+        direction.update(id, &v).context("sparkline update direction")?;
+        max.update(id, &v).context("sparkline update max")?;
+        style.update(id, &v).context("sparkline update style")?;
+        if data_ref.id == id {
+            self.set_data(&v)?;
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, rect: Rect) -> Result<()> {
+        let mut spark = Sparkline::default().data(&self.data);
+        if let Some(Some(m)) = self.max.t {
+            spark = spark.max(m);
+        }
+        if let Some(Some(s)) = &self.style.t {
+            spark = spark.style(s.0);
+        }
+        if let Some(Some(d)) = self.direction.t {
+            spark = spark.direction(d.0);
+        }
+        frame.render_widget(spark, rect);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- expose Sparkline widget via `gui.bs`
- support RenderDirection parameter and dataset updates
- implement SparklineW widget in Rust
- address review comments: allow numeric sparkline data and remove invalid enum variants

## Testing
- `cargo check -q` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_6867ff322ae8832f9b97018d3f3775e0