### PR TITLE
Add LineGauge widget binding

### DIFF
--- a/netidx-tools/src/shell/examples/line-gauge.bs
+++ b/netidx-tools/src/shell/examples/line-gauge.bs
@@ -1,0 +1,21 @@
+use gui;
+
+let trigger = time::timer(duration:0.5s, true);
+let power = 0.0;
+power <- sample(#trigger, min(1.0, power + 0.01));
+
+let color = select power {
+  x if x < 0.10 => `Red,
+  x if x < 0.25 => `Yellow,
+  x => `Green
+};
+
+block(
+  #border:&`All,
+  #title:&line("Power"),
+  &line_gauge(
+    #filled_style:&style(#fg: color),
+    #line_set:&`Thick,
+    &power
+  )
+)

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -9,6 +9,7 @@ mod gui {
     `BarChart(BarChart),
     `Chart(Chart),
     `Sparkline(Sparkline),
+    `LineGauge(LineGauge),
     `Gauge(Gauge)
   ];
 
@@ -619,6 +620,31 @@ mod gui {
     max,
     style
   });
+
+  type LineSet = [
+    `Normal,
+    `Rounded,
+    `Double,
+    `Thick
+  ];
+
+  type LineGauge = {
+    filled_style: &[Style, null],
+    label: &[Line, null],
+    line_set: &[LineSet, null],
+    ratio: &f64,
+    style: &[Style, null],
+    unfilled_style: &[Style, null]
+  };
+
+  let line_gauge = |
+    #filled_style: &[Style, null] = &null,
+    #label: &[Line, null] = &null,
+    #line_set: &[LineSet, null] = &null,
+    #style: &[Style, null] = &null,
+    #unfilled_style: &[Style, null] = &null,
+    ratio: &f64
+  | -> Gui `LineGauge({ filled_style, label, line_set, ratio, style, unfilled_style });
 
   type Gauge = {
     gauge_style: &[Style, null],

--- a/netidx-tools/src/shell/gui/line_gauge.rs
+++ b/netidx-tools/src/shell/gui/line_gauge.rs
@@ -1,0 +1,108 @@
+use super::{into_borrowed_line, GuiW, GuiWidget, LineV, StyleV, TRef};
+use anyhow::{Context, Result};
+use arcstr::ArcStr;
+use async_trait::async_trait;
+use crossterm::event::Event;
+use netidx::publisher::{FromValue, Value};
+use netidx_bscript::{expr::ExprId, rt::{BSHandle, Ref}};
+use ratatui::{
+    layout::Rect,
+    symbols,
+    widgets::LineGauge,
+    Frame,
+};
+use tokio::try_join;
+
+#[derive(Clone, Copy)]
+struct LineSetV(symbols::line::Set);
+
+impl FromValue for LineSetV {
+    fn from_value(v: Value) -> Result<Self> {
+        let s = match &*v.cast_to::<ArcStr>()? {
+            "Normal" => symbols::line::NORMAL,
+            "Rounded" => symbols::line::ROUNDED,
+            "Double" => symbols::line::DOUBLE,
+            "Thick" => symbols::line::THICK,
+            s => bail!("invalid line set {s}"),
+        };
+        Ok(Self(s))
+    }
+}
+
+pub(super) struct LineGaugeW {
+    filled_style: TRef<Option<StyleV>>,
+    label: TRef<Option<LineV>>,
+    line_set: TRef<Option<LineSetV>>,
+    ratio: TRef<f64>,
+    style: TRef<Option<StyleV>>,
+    unfilled_style: TRef<Option<StyleV>>,
+}
+
+impl LineGaugeW {
+    pub(super) async fn compile(bs: BSHandle, v: Value) -> Result<GuiW> {
+        let [(_, filled_style), (_, label), (_, line_set), (_, ratio), (_, style), (_, unfilled_style)] =
+            v.cast_to::<[(ArcStr, u64); 6]>()?;
+        let (filled_style, label, line_set, ratio, style, unfilled_style) = try_join! {
+            bs.compile_ref(filled_style),
+            bs.compile_ref(label),
+            bs.compile_ref(line_set),
+            bs.compile_ref(ratio),
+            bs.compile_ref(style),
+            bs.compile_ref(unfilled_style)
+        }?;
+        Ok(Box::new(Self {
+            filled_style: TRef::new(filled_style).context("line_gauge tref filled_style")?,
+            label: TRef::new(label).context("line_gauge tref label")?,
+            line_set: TRef::new(line_set).context("line_gauge tref line_set")?,
+            ratio: TRef::new(ratio).context("line_gauge tref ratio")?,
+            style: TRef::new(style).context("line_gauge tref style")?,
+            unfilled_style: TRef::new(unfilled_style).context("line_gauge tref unfilled_style")?,
+        }))
+    }
+}
+
+#[async_trait]
+impl GuiWidget for LineGaugeW {
+    async fn handle_event(&mut self, _e: Event) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle_update(&mut self, id: ExprId, v: Value) -> Result<()> {
+        self.filled_style
+            .update(id, &v)
+            .context("line_gauge update filled_style")?;
+        self.label
+            .update(id, &v)
+            .context("line_gauge update label")?;
+        self.line_set
+            .update(id, &v)
+            .context("line_gauge update line_set")?;
+        self.ratio.update(id, &v).context("line_gauge update ratio")?;
+        self.style.update(id, &v).context("line_gauge update style")?;
+        self.unfilled_style
+            .update(id, &v)
+            .context("line_gauge update unfilled_style")?;
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, rect: Rect) -> Result<()> {
+        let mut g = LineGauge::default().ratio(self.ratio.t.unwrap_or(0.0));
+        if let Some(Some(LineV(l))) = &self.label.t {
+            g = g.label(into_borrowed_line(l));
+        }
+        if let Some(Some(ls)) = self.line_set.t {
+            g = g.line_set(ls.0);
+        }
+        if let Some(Some(s)) = &self.style.t {
+            g = g.style(s.0);
+        }
+        if let Some(Some(s)) = &self.filled_style.t {
+            g = g.filled_style(s.0);
+        }
+        if let Some(Some(s)) = &self.unfilled_style.t {
+            g = g.unfilled_style(s.0);
+        }
+        frame.render_widget(g, rect);
+        Ok(())
+    }
+}

--- a/netidx-tools/src/shell/gui/mod.rs
+++ b/netidx-tools/src/shell/gui/mod.rs
@@ -26,6 +26,7 @@ use reedline::Signal;
 use scrollbar::ScrollbarW;
 use smallvec::SmallVec;
 use sparkline::SparklineW;
+use line_gauge::LineGaugeW;
 use std::{borrow::Cow, future::Future, pin::Pin};
 use text::TextW;
 use tokio::{select, sync::oneshot, task};
@@ -38,6 +39,7 @@ mod layout;
 mod paragraph;
 mod scrollbar;
 mod sparkline;
+mod line_gauge;
 mod text;
 
 #[derive(Clone, Copy)]
@@ -290,6 +292,7 @@ fn compile(bs: BSHandle, source: Value) -> CompRes {
             (s, v) if &s == "BarChart" => BarChartW::compile(bs, v).await,
             (s, v) if &s == "Chart" => ChartW::compile(bs, v).await,
             (s, v) if &s == "Sparkline" => SparklineW::compile(bs, v).await,
+            (s, v) if &s == "LineGauge" => LineGaugeW::compile(bs, v).await,
             (s, v) if &s == "Gauge" => GaugeW::compile(bs, v).await,
             (s, v) => bail!("invalid widget type `{s}({v})"),
         }


### PR DESCRIPTION
## Summary
- add bscript types for LineGauge, with LineSet enum
- implement LineGauge widget in Rust
- register the widget in the GUI framework
- provide an example using the new widget

## Testing
- `cargo check -p netidx-tools` *(fails: could not compile `netidx-bscript` due to E0658 let expressions)*

------
https://chatgpt.com/codex/tasks/task_e_68683f7aa384832f943cc3b0cc0a799b