### PR TITLE
Add calendar widget binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bitflags = "2"
 byteorder = "1"
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "^0.4.24", features = ["serde"] }
+time = "0.3"
 combine = "4"
 compact_str = { version = "0.9", features = ["serde"] }
 crossbeam = "0.8"

--- a/netidx-tools/Cargo.toml
+++ b/netidx-tools/Cargo.toml
@@ -65,3 +65,4 @@ smallvec = { workspace = true }
 structopt = { workspace = true }
 tokio = { workspace = true }
 triomphe = { workspace = true }
+time = { workspace = true }

--- a/netidx-tools/src/shell/examples/calendar.bs
+++ b/netidx-tools/src/shell/examples/calendar.bs
@@ -1,0 +1,14 @@
+use gui;
+
+let events = [
+  calendar_event(style(#fg:`Red), date(2024, 5, 5)),
+  calendar_event(style(#fg:`Green), date(2024, 5, 15))
+];
+
+calendar(
+  #show_month: &style(#fg:`Yellow),
+  #show_weekday: &style(#fg:`Cyan),
+  #show_surrounding: &style(#fg:`DarkGray),
+  #events: &events,
+  date(2024, 5, 1)
+)

--- a/netidx-tools/src/shell/examples/calendar.bs
+++ b/netidx-tools/src/shell/examples/calendar.bs
@@ -10,5 +10,5 @@ calendar(
   #show_weekday: &style(#fg:`Cyan),
   #show_surrounding: &style(#fg:`DarkGray),
   #events: &events,
-  date(2024, 5, 1)
+  &date(2024, 5, 1)
 )

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -825,8 +825,7 @@ mod gui {
     selected_column,
     style,
     widths
-  })
-}
+  });
 
   type Date = {
     year: i64,

--- a/netidx-tools/src/shell/gui.bs
+++ b/netidx-tools/src/shell/gui.bs
@@ -14,7 +14,8 @@ mod gui {
     `Gauge(Gauge),
     `InputHandler(InputHandler),
     `List(List),
-    `Table(Table)
+    `Table(Table),
+    `Calendar(Calendar)
   ];
 
   type MediaKeyCode = [
@@ -824,5 +825,46 @@ mod gui {
     selected_column,
     style,
     widths
+  })
+}
+
+  type Date = {
+    year: i64,
+    month: i64,
+    day: i64
+  };
+
+  let date = |year: i64, month: i64, day: i64| -> Date { year, month, day };
+
+  type CalendarEvent = {
+    date: Date,
+    style: Style
+  };
+
+  let calendar_event = |style: Style, date: Date| -> CalendarEvent { date, style };
+
+  type Calendar = {
+    default_style: &[Style, null],
+    display_date: &Date,
+    events: &[Array<CalendarEvent>, null],
+    show_month: &[Style, null],
+    show_surrounding: &[Style, null],
+    show_weekday: &[Style, null]
+  };
+
+  let calendar = |
+    #default_style: &[Style, null] = &null,
+    #show_month: &[Style, null] = &null,
+    #show_surrounding: &[Style, null] = &null,
+    #show_weekday: &[Style, null] = &null,
+    #events: &[Array<CalendarEvent>, null] = &null,
+    display_date: &Date
+  | -> Gui `Calendar({
+    default_style,
+    display_date,
+    events,
+    show_month,
+    show_surrounding,
+    show_weekday
   })
 }

--- a/netidx-tools/src/shell/gui/calendar.rs
+++ b/netidx-tools/src/shell/gui/calendar.rs
@@ -1,0 +1,153 @@
+use super::{GuiW, GuiWidget, StyleV, TRef};
+use anyhow::{bail, Context, Result};
+use arcstr::ArcStr;
+use async_trait::async_trait;
+use crossterm::event::Event;
+use netidx::publisher::{FromValue, Value};
+use netidx_bscript::{expr::ExprId, rt::{BSHandle, Ref}};
+use ratatui::{layout::Rect, widgets::calendar::{CalendarEventStore, Monthly}, Frame};
+use time::{Date, Month};
+use tokio::try_join;
+
+#[derive(Clone, Copy)]
+struct DateV(Date);
+
+impl FromValue for DateV {
+    fn from_value(v: Value) -> Result<Self> {
+        // bscript structs are stored sorted by field name (day, month, year)
+        let [(_, day), (_, month), (_, year)] =
+            v.cast_to::<[(ArcStr, i64); 3]>()?;
+        let month = Month::try_from(month as u8).map_err(|_| anyhow::anyhow!("invalid month {month}"))?;
+        let date = Date::from_calendar_date(year as i32, month, day as u8)?;
+        Ok(Self(date))
+    }
+}
+
+struct EventV {
+    date: DateV,
+    style: StyleV,
+}
+
+impl FromValue for EventV {
+    fn from_value(v: Value) -> Result<Self> {
+        let [(_, date), (_, style)] = v.cast_to::<[(ArcStr, Value); 2]>()?;
+        Ok(Self { date: date.cast_to::<DateV>()?, style: style.cast_to::<StyleV>()? })
+    }
+}
+
+pub(super) struct CalendarW {
+    bs: BSHandle,
+    display_date: TRef<DateV>,
+    events_ref: Ref,
+    events: CalendarEventStore,
+    show_month: TRef<Option<StyleV>>,
+    show_surrounding: TRef<Option<StyleV>>,
+    show_weekday: TRef<Option<StyleV>>,
+    default_style: TRef<Option<StyleV>>,
+}
+
+impl CalendarW {
+    pub(super) async fn compile(bs: BSHandle, v: Value) -> Result<GuiW> {
+        let [(_, default_style), (_, display_date), (_, events), (_, show_month), (_, show_surrounding), (_, show_weekday)] =
+            v.cast_to::<[(ArcStr, u64); 6]>().context("calendar fields")?;
+        let (default_style, display_date, events_ref, show_month, show_surrounding, show_weekday) = try_join! {
+            bs.compile_ref(default_style),
+            bs.compile_ref(display_date),
+            bs.compile_ref(events),
+            bs.compile_ref(show_month),
+            bs.compile_ref(show_surrounding),
+            bs.compile_ref(show_weekday)
+        }?;
+        let mut t = Self {
+            bs: bs.clone(),
+            display_date: TRef::new(display_date).context("calendar tref display_date")?,
+            events_ref,
+            events: CalendarEventStore::default(),
+            show_month: TRef::new(show_month).context("calendar tref show_month")?,
+            show_surrounding: TRef::new(show_surrounding).context("calendar tref show_surrounding")?,
+            show_weekday: TRef::new(show_weekday).context("calendar tref show_weekday")?,
+            default_style: TRef::new(default_style).context("calendar tref default_style")?,
+        };
+        if let Some(v) = t.events_ref.last.take() {
+            t.set_events(&v)?;
+        }
+        Ok(Box::new(t))
+    }
+
+    fn set_events(&mut self, v: &Value) -> Result<()> {
+        self.events = CalendarEventStore::default();
+        match v {
+            Value::Null => return Ok(()),
+            Value::Array(a) => {
+                for ev in a {
+                    let EventV { date, style } = ev.clone().cast_to::<EventV>()?;
+                    self.events.add(date.0, style.0);
+                }
+            }
+            v => bail!("invalid calendar events {v}"),
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl GuiWidget for CalendarW {
+    async fn handle_event(&mut self, _e: Event) -> Result<()> { Ok(()) }
+
+    async fn handle_update(&mut self, id: ExprId, v: Value) -> Result<()> {
+        let Self {
+            bs: _,
+            display_date,
+            events_ref,
+            events: _,
+            show_month,
+            show_surrounding,
+            show_weekday,
+            default_style,
+        } = self;
+        display_date
+            .update(id, &v)
+            .context("calendar update display_date")?;
+        show_month.update(id, &v).context("calendar update show_month")?;
+        show_surrounding
+            .update(id, &v)
+            .context("calendar update show_surrounding")?;
+        show_weekday.update(id, &v).context("calendar update show_weekday")?;
+        default_style
+            .update(id, &v)
+            .context("calendar update default_style")?;
+        if events_ref.id == id {
+            self.set_events(&v)?;
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame, rect: Rect) -> Result<()> {
+        let Self {
+            bs: _,
+            display_date,
+            events_ref: _,
+            events,
+            show_month,
+            show_surrounding,
+            show_weekday,
+            default_style,
+        } = self;
+        let mut cal = Monthly::new(display_date.t.unwrap().0, &*events);
+        if let Some(Some(s)) = &show_surrounding.t {
+            cal = cal.show_surrounding(s.0);
+        }
+        if let Some(Some(s)) = &show_weekday.t {
+            cal = cal.show_weekdays_header(s.0);
+        }
+        if let Some(Some(s)) = &show_month.t {
+            cal = cal.show_month_header(s.0);
+        }
+        if let Some(Some(s)) = &default_style.t {
+            cal = cal.default_style(s.0);
+        }
+        frame.render_widget(cal, rect);
+        Ok(())
+    }
+}
+

--- a/netidx-tools/src/shell/gui/mod.rs
+++ b/netidx-tools/src/shell/gui/mod.rs
@@ -11,6 +11,7 @@ use input_handler::InputHandlerW;
 use layout::LayoutW;
 use line_gauge::LineGaugeW;
 use list::ListW;
+use calendar::CalendarW;
 use log::error;
 use netidx::publisher::{FromValue, Value};
 use netidx_bscript::{
@@ -44,6 +45,7 @@ mod list;
 mod paragraph;
 mod scrollbar;
 mod sparkline;
+mod calendar;
 mod table;
 mod tabs;
 mod text;
@@ -331,6 +333,7 @@ fn compile(bs: BSHandle, source: Value) -> CompRes {
             (s, v) if &s == "Chart" => ChartW::compile(bs, v).await,
             (s, v) if &s == "Sparkline" => SparklineW::compile(bs, v).await,
             (s, v) if &s == "LineGauge" => LineGaugeW::compile(bs, v).await,
+            (s, v) if &s == "Calendar" => CalendarW::compile(bs, v).await,
             (s, v) if &s == "Table" => table::TableW::compile(bs, v).await,
             (s, v) if &s == "Gauge" => GaugeW::compile(bs, v).await,
             (s, v) if &s == "List" => ListW::compile(bs, v).await,


### PR DESCRIPTION
## Summary
- add `Calendar` bindings in `gui.bs`
- implement calendar widget support in Rust
- expose calendar module via `gui::calendar`
- provide a `calendar.bs` example
- add `time` dependency for calendar parsing

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_686d85f125f4832f8135d4936a406696